### PR TITLE
Add and use type alias for connection properties

### DIFF
--- a/sdbus_async/networkmanager/__init__.py
+++ b/sdbus_async/networkmanager/__init__.py
@@ -195,7 +195,7 @@ from .exceptions import (
 )
 from .types import (
     NetworkManagerSetting,
-    NetworkManagerSettingsGroup,
+    NetworkManagerSettingsDomain,
     NetworkManagerConnectionProperties,
 )
 
@@ -371,6 +371,6 @@ __all__ = (
     'NmVpnPluginInteractiveNotSupportedError',
 
     'NetworkManagerSetting',
-    'NetworkManagerSettingsGroup',
+    'NetworkManagerSettingsDomain',
     'NetworkManagerConnectionProperties',
 )

--- a/sdbus_async/networkmanager/__init__.py
+++ b/sdbus_async/networkmanager/__init__.py
@@ -193,6 +193,11 @@ from .exceptions import (
     NmVpnPluginInvalidConnectionError,
     NmVpnPluginInteractiveNotSupportedError,
 )
+from .types import (
+    NetworkManagerSetting,
+    NetworkManagerSettingsGroup,
+    NetworkManagerConnectionProperties,
+)
 
 DEVICE_TYPE_TO_CLASS = {
     DeviceType.ETHERNET: NetworkDeviceWired,
@@ -364,4 +369,8 @@ __all__ = (
     'NmVpnPluginLaunchFailedError',
     'NmVpnPluginInvalidConnectionError',
     'NmVpnPluginInteractiveNotSupportedError',
+
+    'NetworkManagerSetting',
+    'NetworkManagerSettingsGroup',
+    'NetworkManagerConnectionProperties',
 )

--- a/sdbus_async/networkmanager/interfaces_other.py
+++ b/sdbus_async/networkmanager/interfaces_other.py
@@ -24,6 +24,8 @@ from typing import Any, Dict, List, Tuple
 from sdbus import (DbusInterfaceCommonAsync, dbus_method_async,
                    dbus_property_async, dbus_signal_async)
 
+from .types import NetworkManagerConnectionProperties
+
 
 class NetworkManagerAccessPointInterfaceAsync(
         DbusInterfaceCommonAsync,
@@ -464,7 +466,7 @@ class NetworkManagerSecretAgentInterfaceAsync(
     )
     async def get_secrets(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         connection_path: str,
         setting_name: str,
         hints: List[str],
@@ -485,7 +487,7 @@ class NetworkManagerSecretAgentInterfaceAsync(
     @dbus_method_async('a{sa{sv}}o')
     async def save_secrets(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         connection_path: str,
     ) -> None:
         """Save given secrets"""
@@ -494,7 +496,7 @@ class NetworkManagerSecretAgentInterfaceAsync(
     @dbus_method_async('a{sa{sv}}o')
     async def delete_secrets(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         connection_path: str,
     ) -> None:
         """Delete secrets"""
@@ -509,7 +511,7 @@ class NetworkManagerSettingsConnectionInterfaceAsync(
     @dbus_method_async('a{sa{sv}}')
     async def update(
         self,
-        properties: Dict[str, Dict[str, Tuple[str, Any]]],
+        properties: NetworkManagerConnectionProperties,
     ) -> None:
         """Update connection settings.
 
@@ -520,7 +522,7 @@ class NetworkManagerSettingsConnectionInterfaceAsync(
     @dbus_method_async('a{sa{sv}}')
     async def update_unsaved(
         self,
-        properties: Dict[str, Dict[str, Tuple[str, Any]]],
+        properties: NetworkManagerConnectionProperties,
     ) -> None:
         """Update connection settings but do not save to disk"""
         raise NotImplementedError
@@ -537,7 +539,7 @@ class NetworkManagerSettingsConnectionInterfaceAsync(
     )
     async def get_settings(
         self,
-    ) -> Dict[str, Dict[str, Tuple[str, Any]]]:
+    ) -> NetworkManagerConnectionProperties:
         """Get connection settings"""
         raise NotImplementedError
 
@@ -572,7 +574,7 @@ class NetworkManagerSettingsConnectionInterfaceAsync(
     )
     async def update2(
         self,
-        settings: Dict[str, Dict[str, Tuple[str, Any]]],
+        settings: NetworkManagerConnectionProperties,
         flags: int,
         args: Dict[str, Tuple[str, Any]],
     ) -> Dict[str, Tuple[str, Any]]:
@@ -639,7 +641,7 @@ class NetworkManagerSettingsInterfaceAsync(
     )
     async def add_connection(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
     ) -> str:
         """Add connection and save to disk"""
         raise NotImplementedError
@@ -650,7 +652,7 @@ class NetworkManagerSettingsInterfaceAsync(
     )
     async def add_connection_unsaved(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
     ) -> str:
         """Add connection and do not save"""
         raise NotImplementedError
@@ -661,7 +663,7 @@ class NetworkManagerSettingsInterfaceAsync(
     )
     async def add_connection2(
         self,
-        settings: Dict[str, Dict[str, Tuple[str, Any]]],
+        settings: NetworkManagerConnectionProperties,
         flags: int,
         args: Dict[str, Tuple[str, Any]],
     ) -> Tuple[str, Dict[str, Tuple[str, Any]]]:
@@ -736,7 +738,7 @@ class NetworkManagerVPNPluginInterfaceAsync(
     @dbus_method_async('a{sa{sv}}')
     async def connect(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
     ) -> None:
         """Connect to described connection
 
@@ -747,7 +749,7 @@ class NetworkManagerVPNPluginInterfaceAsync(
     @dbus_method_async('a{sa{sv}}a{sv}')
     async def connect_interactive(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         details: Dict[str, Tuple[str, Any]],
     ) -> None:
         """Connect to described connection
@@ -763,7 +765,7 @@ class NetworkManagerVPNPluginInterfaceAsync(
     )
     async def need_secrets(
         self,
-        settings: Dict[str, Dict[str, Tuple[str, Any]]],
+        settings: NetworkManagerConnectionProperties,
     ) -> str:
         """Asks plugin if connection will require secrets
 
@@ -813,9 +815,12 @@ class NetworkManagerVPNPluginInterfaceAsync(
     @dbus_method_async('a{sa{sv}}')
     async def new_secrets(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
     ) -> None:
-        """Called in response to secrets_required signal"""
+        """Called in response to secrets_required signal
+
+        param: Describes the connection including the new secrets.
+        """
         raise NotImplementedError
 
     @dbus_property_async('u')
@@ -999,7 +1004,7 @@ class NetworkManagerInterfaceAsync(
     )
     async def add_and_activate_connection(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         device: str,
         specific_object: str,
     ) -> Tuple[str, str]:
@@ -1012,7 +1017,7 @@ class NetworkManagerInterfaceAsync(
     )
     async def add_and_activate_connection2(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         device: str,
         specific_object: str,
         options: Dict[str, Tuple[str, Any]],

--- a/sdbus_async/networkmanager/types.py
+++ b/sdbus_async/networkmanager/types.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 igo95862
+# Copyright (C) 2022 igo95862, bernhardkaindl
 
 # This file is part of python-sdbus
 
@@ -22,8 +22,8 @@ from typing import Any, Dict, Tuple
 # "Any" might be str, int, bool (e.g. autoconnect), List[Ip] and maybe others
 NetworkManagerSetting = Tuple[str, Any]
 
-# A group of settings, eg. "connection", "ipv4, "ipv6", etc:
-NetworkManagerSettingsGroup = Dict[str, NetworkManagerSetting]
+# A settings domain, e.g. ipv4.*, ipv6.*, 802-11-wireless-security.*, etc:
+NetworkManagerSettingsDomain = Dict[str, NetworkManagerSetting]
 
 # All settings and properites of a connection, e.g. returned by get_settings()
-NetworkManagerConnectionProperties = Dict[str, NetworkManagerSettingsGroup]
+NetworkManagerConnectionProperties = Dict[str, NetworkManagerSettingsDomain]

--- a/sdbus_async/networkmanager/types.py
+++ b/sdbus_async/networkmanager/types.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2022 igo95862
+
+# This file is part of python-sdbus
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+from typing import Any, Dict, Tuple
+
+# Type aliases for network connection settings and properties
+
+# "Any" might be str, int, bool (e.g. autoconnect), List[Ip] and maybe others
+NetworkManagerSetting = Tuple[str, Any]
+
+# A group of settings, eg. "connection", "ipv4, "ipv6", etc:
+NetworkManagerSettingsGroup = Dict[str, NetworkManagerSetting]
+
+# All settings and properites of a connection, e.g. returned by get_settings()
+NetworkManagerConnectionProperties = Dict[str, NetworkManagerSettingsGroup]

--- a/sdbus_block/networkmanager/__init__.py
+++ b/sdbus_block/networkmanager/__init__.py
@@ -151,6 +151,11 @@ from .exceptions import (
     NmVpnPluginInvalidConnectionError,
     NmVpnPluginInteractiveNotSupportedError,
 )
+from .types import (
+    NetworkManagerSetting,
+    NetworkManagerSettingsGroup,
+    NetworkManagerConnectionProperties,
+)
 
 DEVICE_TYPE_TO_CLASS = {
     DeviceType.ETHERNET: NetworkDeviceWired,
@@ -322,4 +327,8 @@ __all__ = (
     'NmVpnPluginLaunchFailedError',
     'NmVpnPluginInvalidConnectionError',
     'NmVpnPluginInteractiveNotSupportedError',
+
+    'NetworkManagerSetting',
+    'NetworkManagerSettingsGroup',
+    'NetworkManagerConnectionProperties',
 )

--- a/sdbus_block/networkmanager/__init__.py
+++ b/sdbus_block/networkmanager/__init__.py
@@ -153,7 +153,7 @@ from .exceptions import (
 )
 from .types import (
     NetworkManagerSetting,
-    NetworkManagerSettingsGroup,
+    NetworkManagerSettingsDomain,
     NetworkManagerConnectionProperties,
 )
 
@@ -329,6 +329,6 @@ __all__ = (
     'NmVpnPluginInteractiveNotSupportedError',
 
     'NetworkManagerSetting',
-    'NetworkManagerSettingsGroup',
+    'NetworkManagerSettingsDomain',
     'NetworkManagerConnectionProperties',
 )

--- a/sdbus_block/networkmanager/interfaces_other.py
+++ b/sdbus_block/networkmanager/interfaces_other.py
@@ -23,6 +23,8 @@ from typing import Any, Dict, List, Tuple
 
 from sdbus import DbusInterfaceCommon, dbus_method, dbus_property
 
+from .types import NetworkManagerConnectionProperties
+
 
 class NetworkManagerAccessPointInterface(
         DbusInterfaceCommon,
@@ -446,7 +448,7 @@ class NetworkManagerSecretAgentInterface(
     )
     def get_secrets(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         connection_path: str,
         setting_name: str,
         hints: List[str],
@@ -467,7 +469,7 @@ class NetworkManagerSecretAgentInterface(
     @dbus_method('a{sa{sv}}o')
     def save_secrets(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         connection_path: str,
     ) -> None:
         """Save given secrets"""
@@ -476,7 +478,7 @@ class NetworkManagerSecretAgentInterface(
     @dbus_method('a{sa{sv}}o')
     def delete_secrets(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         connection_path: str,
     ) -> None:
         """Delete secrets"""
@@ -491,7 +493,7 @@ class NetworkManagerSettingsConnectionInterface(
     @dbus_method('a{sa{sv}}')
     def update(
         self,
-        properties: Dict[str, Dict[str, Tuple[str, Any]]],
+        properties: NetworkManagerConnectionProperties,
     ) -> None:
         """Update connection settings.
 
@@ -502,7 +504,7 @@ class NetworkManagerSettingsConnectionInterface(
     @dbus_method('a{sa{sv}}')
     def update_unsaved(
         self,
-        properties: Dict[str, Dict[str, Tuple[str, Any]]],
+        properties: NetworkManagerConnectionProperties,
     ) -> None:
         """Update connection settings but do not save to disk"""
         raise NotImplementedError
@@ -519,7 +521,7 @@ class NetworkManagerSettingsConnectionInterface(
     )
     def get_settings(
         self,
-    ) -> Dict[str, Dict[str, Tuple[str, Any]]]:
+    ) -> NetworkManagerConnectionProperties:
         """Get connection settings"""
         raise NotImplementedError
 
@@ -554,7 +556,7 @@ class NetworkManagerSettingsConnectionInterface(
     )
     def update2(
         self,
-        settings: Dict[str, Dict[str, Tuple[str, Any]]],
+        settings: NetworkManagerConnectionProperties,
         flags: int,
         args: Dict[str, Tuple[str, Any]],
     ) -> Dict[str, Tuple[str, Any]]:
@@ -611,7 +613,7 @@ class NetworkManagerSettingsInterface(
     )
     def add_connection(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
     ) -> str:
         """Add connection and save to disk"""
         raise NotImplementedError
@@ -622,7 +624,7 @@ class NetworkManagerSettingsInterface(
     )
     def add_connection_unsaved(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
     ) -> str:
         """Add connection and do not save"""
         raise NotImplementedError
@@ -633,7 +635,7 @@ class NetworkManagerSettingsInterface(
     )
     def add_connection2(
         self,
-        settings: Dict[str, Dict[str, Tuple[str, Any]]],
+        settings: NetworkManagerConnectionProperties,
         flags: int,
         args: Dict[str, Tuple[str, Any]],
     ) -> Tuple[str, Dict[str, Tuple[str, Any]]]:
@@ -698,7 +700,7 @@ class NetworkManagerVPNPluginInterface(
     @dbus_method('a{sa{sv}}')
     def connect(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
     ) -> None:
         """Connect to described connection
 
@@ -709,7 +711,7 @@ class NetworkManagerVPNPluginInterface(
     @dbus_method('a{sa{sv}}a{sv}')
     def connect_interactive(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         details: Dict[str, Tuple[str, Any]],
     ) -> None:
         """Connect to described connection
@@ -725,7 +727,7 @@ class NetworkManagerVPNPluginInterface(
     )
     def need_secrets(
         self,
-        settings: Dict[str, Dict[str, Tuple[str, Any]]],
+        settings: NetworkManagerConnectionProperties,
     ) -> str:
         """Asks plugin if connection will require secrets
 
@@ -775,9 +777,12 @@ class NetworkManagerVPNPluginInterface(
     @dbus_method('a{sa{sv}}')
     def new_secrets(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
     ) -> None:
-        """Called in response to secrets_required signal"""
+        """Called in response to secrets_required signal
+
+        param: Describes the connection including the new secrets
+        """
         raise NotImplementedError
 
     @dbus_property('u')
@@ -920,7 +925,7 @@ class NetworkManagerInterface(
     )
     def add_and_activate_connection(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         device: str,
         specific_object: str,
     ) -> Tuple[str, str]:
@@ -933,7 +938,7 @@ class NetworkManagerInterface(
     )
     def add_and_activate_connection2(
         self,
-        connection: Dict[str, Dict[str, Tuple[str, Any]]],
+        connection: NetworkManagerConnectionProperties,
         device: str,
         specific_object: str,
         options: Dict[str, Tuple[str, Any]],

--- a/sdbus_block/networkmanager/types.py
+++ b/sdbus_block/networkmanager/types.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 igo95862
+# Copyright (C) 2022 igo95862, bernhardkaindl
 
 # This file is part of python-sdbus
 
@@ -22,8 +22,8 @@ from typing import Any, Dict, Tuple
 # "Any" might be str, int, bool (e.g. autoconnect), List[Ip] and maybe others
 NetworkManagerSetting = Tuple[str, Any]
 
-# A group of settings, eg. "connection", "ipv4, "ipv6", etc:
-NetworkManagerSettingsGroup = Dict[str, NetworkManagerSetting]
+# A settings domain, e.g. ipv4.*, ipv6.*, 802-11-wireless-security.*, etc:
+NetworkManagerSettingsDomain = Dict[str, NetworkManagerSetting]
 
 # All settings and properites of a connection, e.g. returned by get_settings()
-NetworkManagerConnectionProperties = Dict[str, NetworkManagerSettingsGroup]
+NetworkManagerConnectionProperties = Dict[str, NetworkManagerSettingsDomain]

--- a/sdbus_block/networkmanager/types.py
+++ b/sdbus_block/networkmanager/types.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2022 igo95862
+
+# This file is part of python-sdbus
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+from typing import Any, Dict, Tuple
+
+# Type aliases for network connection settings and properties
+
+# "Any" might be str, int, bool (e.g. autoconnect), List[Ip] and maybe others
+NetworkManagerSetting = Tuple[str, Any]
+
+# A group of settings, eg. "connection", "ipv4, "ipv6", etc:
+NetworkManagerSettingsGroup = Dict[str, NetworkManagerSetting]
+
+# All settings and properites of a connection, e.g. returned by get_settings()
+NetworkManagerConnectionProperties = Dict[str, NetworkManagerSettingsGroup]


### PR DESCRIPTION
In Pull reqest #5, @igo95862 [3 days ago](https://github.com/python-sdbus/python-sdbus-networkmanager/pull/5#discussion_r835807746) wrote:
> I am going to try adding those types. Not sure how sphinx will react to it.

Add and use type alias NetworkManagerConnectionProperties

Since I want to update the example to use these type aliases from [python-sdbus-networkmanager](https://github.com/python-sdbus/python-sdbus-networkmanager), I'm submitting an initial shot of adding them using a new file, exporting them and using them in `networkmanager/interfaces_other.py` for the methods which add and update connections:
```py
# Type aliases for network connection settings and properties

# "Any" might be str, int, bool (e.g. autoconnect), List[Ip] and maybe others
NetworkManagerSetting = Tuple[str, Any]

# A settings domain, e.g. ipv4.*, ipv6.*, 802-11-wireless-security.*, etc:
NetworkManagerSettingsDomain = Dict[str, NetworkManagerSetting]

# All settings and properites of a connection, e.g. returned by get_settings()
NetworkManagerConnectionProperties = Dict[str, NetworkManagerSettingsDomain]
```
@igo95862: Sphinx unfolds the type alias to `Dict[str, Dict[str, Tuple[str, Any]]]`:
There is no change in the generated docs.