### PR TITLE
next merge: Helper NetworkManagerSettings.get_connections_by_id()

### DIFF
--- a/sdbus_async/networkmanager/objects.py
+++ b/sdbus_async/networkmanager/objects.py
@@ -21,7 +21,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 from __future__ import annotations
 
-from typing import Optional
+from typing import List, Optional
 
 from sdbus.sd_bus_internals import SdBus
 
@@ -153,6 +153,24 @@ class NetworkManagerSettings(NetworkManagerSettingsInterfaceAsync):
             NETWORK_MANAGER_SERVICE_NAME,
             '/org/freedesktop/NetworkManager/Settings',
             bus)
+
+    async def get_connections_by_id(self, connection_id: str) -> List[str]:
+        """Helper method to get a list of connection profile paths
+        which use the given connection identifier.
+
+        :param str connection_id: The connection identifier of the connections,
+        e.g. "Ethernet connection 1"
+        :return: List of connection profile paths using the given identifier.
+        """
+        connection_paths_with_matching_id = []
+        connection_paths: List[str] = await self.connections
+        for connection_path in connection_paths:
+            settings = NetworkConnectionSettings(connection_path)
+            settings_properites = await settings.get_settings()
+            # settings_properites["connection"]["id"][1] gives the id value:
+            if settings_properites["connection"]["id"][1] == connection_id:
+                connection_paths_with_matching_id.append(connection_path)
+        return connection_paths_with_matching_id
 
 
 class NetworkConnectionSettings(

--- a/sdbus_block/networkmanager/objects.py
+++ b/sdbus_block/networkmanager/objects.py
@@ -21,7 +21,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 from __future__ import annotations
 
-from typing import Optional
+from typing import List, Optional
 
 from sdbus.sd_bus_internals import SdBus
 
@@ -148,6 +148,22 @@ class NetworkManagerSettings(NetworkManagerSettingsInterface):
             NETWORK_MANAGER_SERVICE_NAME,
             '/org/freedesktop/NetworkManager/Settings',
             bus)
+
+    def get_connections_by_id(self, connection_id: str) -> List[str]:
+        """Helper method to get a list of connection profile paths
+        which use the given connection identifier.
+
+        :param str connection_id: The connection identifier of the connections,
+        e.g. "Ethernet connection 1"
+        :return: List of connection profile paths using the given identifier.
+        """
+        connection_paths_with_matching_id = []
+        for connection_path in self.connections:
+            profile = NetworkConnectionSettings(connection_path)
+            # profile.get_settings()["connection"]["id"][1] gives the id value:
+            if profile.get_settings()["connection"]["id"][1] == connection_id:
+                connection_paths_with_matching_id.append(connection_path)
+        return connection_paths_with_matching_id
 
 
 class NetworkConnectionSettings(


### PR DESCRIPTION
In PR #6, where I initially added a `connection_by_id()` function for the purpose of that example, I didn't account for the fact that NetworkManager can have many connections with the same `id`. Only the `uuid` is guaranteed to be unique.

For a helper method like you suggested to be provided by [python-sdbus-networkmanager](https://github.com/python-sdbus/python-sdbus-networkmanager), we should be able to potentially return multiple connections, so I'd return a list of them.

This PR provides this helper in the `NetworkManagerSettings` class, alongside the `get_connection_by_uuid` which is provided as part of the DBus interface by this class.

An example use in examples which add connections can look like this:
```py
    if NetworkManagerSettings().get_connections_by_id(args.conn_id):
        print(f'Connections using ID "{args.conn_id}" exist, remove them:')
        print(f'Run: nmcli connection delete "{args.conn_id}"')
        return
```