### PR TITLE
Update example add-wifi-psk-connection-async.py

### DIFF
--- a/examples/async/add-wifi-psk-connection-async.py
+++ b/examples/async/add-wifi-psk-connection-async.py
@@ -3,7 +3,7 @@
 #
 # Example to create a new WiFi-PSK network connection profile:
 #
-# $ add-wifi-psk-connection.py --help
+# $ examples/async/add-wifi-psk-connection-async.py --help
 # usage: add-wifi-psk-connection.py [-h] [-c CONN_ID] [-s SSID] [-p PSK]
 #                                   [-i INTERFACE_NAME] [-a] [--save]
 #
@@ -12,6 +12,7 @@
 # optional arguments:
 #   -h, --help         show this help message and exit
 #   -c CONN_ID         Connection Id
+#   -u UUID            Connection UUID
 #   -s SSID            WiFi SSID
 #   -p PSK             WiFi PSK
 #   -i INTERFACE_NAME  WiFi device
@@ -45,27 +46,32 @@
 
 import asyncio
 import functools
+import logging
 import pprint
 import sdbus
-import uuid
+from uuid import uuid4
 from argparse import ArgumentParser, Namespace
 from sdbus_async.networkmanager import NetworkManagerSettings
 from sdbus_async.networkmanager import NetworkManagerConnectionProperties
 
 
-async def add_wifi_psk_connection_profile_async(args: Namespace) -> None:
-    """Add a temporary (not yet saved) network connection profile"""
+async def add_wifi_psk_connection_profile_async(args: Namespace) -> str:
+    """Add a temporary (not yet saved) network connection profile
+    :param Namespace args: autoconnect, conn_id, psk, save, ssid, uuid
+    :return: dbus connection path of the created connection profile
+    """
+    info = logging.getLogger().info
 
     # If we add many connections passing the same id, things get messy. Check:
     if await NetworkManagerSettings().get_connections_by_id(args.conn_id):
         print(f'Connection "{args.conn_id}" exists, remove it first')
         print(f'Run: nmcli connection delete "{args.conn_id}"')
-        return
+        return ""
 
     properties: NetworkManagerConnectionProperties = {
         "connection": {
             "id": ("s", args.conn_id),
-            "uuid": ("s", str(uuid.uuid4())),
+            "uuid": ("s", str(args.uuid)),
             "type": ("s", "802-11-wireless"),
             "autoconnect": ("b", args.auto),
         },
@@ -87,23 +93,23 @@ async def add_wifi_psk_connection_profile_async(args: Namespace) -> None:
     if args.interface_name:
         properties["connection"]["interface-name"] = ("s", args.interface_name)
 
-    networkmanager_settings = NetworkManagerSettings()
-    if args.save:
-        await networkmanager_settings.add_connection(properties)
-        print("New connection profile created and saved, show it with:")
-    else:
-        await networkmanager_settings.add_connection_unsaved(properties)
-        print("New unsaved connection profile created, show it with:")
-
-    print(f'nmcli connection show "{args.conn_id}"|grep -v -e -- -e default')
-    print("Settings used:")
-    functools.partial(pprint.pprint, sort_dicts=False)(properties)
+    s = NetworkManagerSettings()
+    addconnection = s.add_connection if args.save else s.add_connection_unsaved
+    connection_settings_dbus_path = await addconnection(properties)
+    created = "created and saved" if args.save else "created"
+    info(f"New unsaved connection profile {created}, show it with:")
+    info(f'nmcli connection show "{args.conn_id}"|grep -v -e -- -e default')
+    info("Settings used:")
+    info(functools.partial(pprint.pformat, sort_dicts=False)(properties))
+    return connection_settings_dbus_path
 
 
 if __name__ == "__main__":
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
     p = ArgumentParser(description="Optional arguments have example values:")
     conn_id = "MyConnectionExample"
     p.add_argument("-c", dest="conn_id", default=conn_id, help="Connection Id")
+    p.add_argument("-u", dest="uuid", default=uuid4(), help="Connection UUID")
     p.add_argument("-s", dest="ssid", default="CafeSSID", help="WiFi SSID")
     p.add_argument("-p", dest="psk", default="Coffee!!", help="WiFi PSK")
     p.add_argument("-i", dest="interface_name", default="", help="WiFi device")
@@ -111,4 +117,6 @@ if __name__ == "__main__":
     p.add_argument("--save", dest="save", action="store_true", help="Save")
     args = p.parse_args()
     sdbus.set_default_bus(sdbus.sd_bus_open_system())
-    asyncio.run(add_wifi_psk_connection_profile_async(args))
+    connection_dpath = asyncio.run(add_wifi_psk_connection_profile_async(args))
+    print(f"Path of the new connection: {connection_dpath}")
+    print(f"UUID of the new connection: {args.uuid}")


### PR DESCRIPTION
Add -u UUID parameter and make it usable from other examples:

- Pass the UUID to the function so it can be passed from another caller.
- Return the DBus path of the created connection to the caller.
- Use `getLogger().info()` instead of `print()` to allow to customize
  if we want the output of the local function shown when importing.