### PR TITLE
add-wifi-psk-connection: check return value of example

### DIFF
--- a/examples/async/add-wifi-psk-connection-async.py
+++ b/examples/async/add-wifi-psk-connection-async.py
@@ -55,7 +55,7 @@ from sdbus_async.networkmanager import NetworkManagerSettings
 from sdbus_async.networkmanager import NetworkManagerConnectionProperties
 
 
-async def add_wifi_psk_connection_profile_async(args: Namespace) -> str:
+async def add_wifi_psk_connection_async(args: Namespace) -> str:
     """Add a temporary (not yet saved) network connection profile
     :param Namespace args: autoconnect, conn_id, psk, save, ssid, uuid
     :return: dbus connection path of the created connection profile
@@ -117,6 +117,8 @@ if __name__ == "__main__":
     p.add_argument("--save", dest="save", action="store_true", help="Save")
     args = p.parse_args()
     sdbus.set_default_bus(sdbus.sd_bus_open_system())
-    connection_dpath = asyncio.run(add_wifi_psk_connection_profile_async(args))
-    print(f"Path of the new connection: {connection_dpath}")
-    print(f"UUID of the new connection: {args.uuid}")
+    if connection_dpath := asyncio.run(add_wifi_psk_connection_async(args)):
+        print(f"Path of the new connection: {connection_dpath}")
+        print(f"UUID of the new connection: {args.uuid}")
+    else:
+        print("Error: No new connection created.")

--- a/examples/block/add-wifi-psk-connection.py
+++ b/examples/block/add-wifi-psk-connection.py
@@ -54,7 +54,7 @@ from sdbus_block.networkmanager import NetworkManagerSettings
 from sdbus_block.networkmanager import NetworkManagerConnectionProperties
 
 
-def add_wifi_psk_connection_profile(args: Namespace) -> str:
+def add_wifi_psk_connection(args: Namespace) -> str:
     """Add a temporary (not yet saved) network connection profile
     :param Namespace args: autoconnect, conn_id, psk, save, ssid, uuid
     :return: dbus connection path of the created connection profile
@@ -116,6 +116,8 @@ if __name__ == "__main__":
     p.add_argument("--save", dest="save", action="store_true", help="Save")
     args = p.parse_args()
     sdbus.set_default_bus(sdbus.sd_bus_open_system())
-    connection_dpath = add_wifi_psk_connection_profile(args)
-    print(f"Path of the new connection: {connection_dpath}")
-    print(f"UUID of the new connection: {args.uuid}")
+    if connection_dpath := add_wifi_psk_connection(args):
+        print(f"Path of the new connection: {connection_dpath}")
+        print(f"UUID of the new connection: {args.uuid}")
+    else:
+        print("Error: No new connection created.")


### PR DESCRIPTION
Check the return value of the example function before declaring success.
(And the function name had to be shortened to still fit into 79 columns)