### PR TITLE
Add delete-connection-by-uuid example

### DIFF
--- a/examples/async/add-wifi-psk-connection-async.py
+++ b/examples/async/add-wifi-psk-connection-async.py
@@ -73,7 +73,7 @@ async def add_wifi_psk_connection_profile_async(args: Namespace) -> str:
             "id": ("s", args.conn_id),
             "uuid": ("s", str(args.uuid)),
             "type": ("s", "802-11-wireless"),
-            "autoconnect": ("b", args.auto),
+            "autoconnect": ("b", bool(hasattr(args, "auto") and args.auto)),
         },
         "802-11-wireless": {
             "mode": ("s", "infrastructure"),
@@ -90,13 +90,14 @@ async def add_wifi_psk_connection_profile_async(args: Namespace) -> str:
     }
 
     # To bind the new connection to a specific interface, use this:
-    if args.interface_name:
+    if hasattr(args, "interface_name") and args.interface_name:
         properties["connection"]["interface-name"] = ("s", args.interface_name)
 
     s = NetworkManagerSettings()
-    addconnection = s.add_connection if args.save else s.add_connection_unsaved
+    save = bool(hasattr(args, "save") and args.save)
+    addconnection = s.add_connection if save else s.add_connection_unsaved
     connection_settings_dbus_path = await addconnection(properties)
-    created = "created and saved" if args.save else "created"
+    created = "created and saved" if save else "created"
     info(f"New unsaved connection profile {created}, show it with:")
     info(f'nmcli connection show "{args.conn_id}"|grep -v -e -- -e default')
     info("Settings used:")

--- a/examples/async/delete-connection-by-uuid-async.py
+++ b/examples/async/delete-connection-by-uuid-async.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Update a property of a connection profile, looked up by connection id
+#
+# The IPv4 settings of connections profiles are documented here:
+# https://networkmanager.dev/docs/api/latest/settings-ipv4.html
+#
+import asyncio
+import logging
+import sdbus
+from uuid import uuid4
+from argparse import Namespace
+from sdbus_async.networkmanager import NetworkManagerSettings
+from sdbus_async.networkmanager import NetworkConnectionSettings
+
+
+async def delete_connection_by_uuid(uuid: str) -> bool:
+    """Find and delete the connection identified by the given UUID"""
+    settings_manager = NetworkManagerSettings()
+    connection_path = await settings_manager.get_connection_by_uuid(uuid)
+    if not connection_path:
+        logging.getLogger().fatal(f"Connection {uuid} for deletion not found")
+        return False
+    connection_settings = NetworkConnectionSettings(connection_path)
+    await connection_settings.delete()
+    return True
+
+
+async def create_and_delete_wifi_psk_connection_async(args: Namespace) -> bool:
+    """Add a temporary (not yet saved) network connection profile
+    :param Namespace args: autoconnect, conn_id, psk, save, ssid, uuid
+    :return: dbus connection path of the created connection profile
+    """
+    add_wifi_psk_connection = __import__("add-wifi-psk-connection-async")
+    if not await add_wifi_psk_connection.add_wifi_psk_connection_async(args):
+        return False
+    return await delete_connection_by_uuid(str(args.uuid))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="%(message)s", level=logging.WARNING)
+    sdbus.set_default_bus(sdbus.sd_bus_open_system())
+    args = Namespace(conn_id="Example", uuid=uuid4(), ssid="S", psk="Password")
+    if asyncio.run(create_and_delete_wifi_psk_connection_async(args)):
+        print(f"Succeeded in creating and deleting connection {args.uuid}")

--- a/examples/block/add-wifi-psk-connection.py
+++ b/examples/block/add-wifi-psk-connection.py
@@ -72,7 +72,7 @@ def add_wifi_psk_connection_profile(args: Namespace) -> str:
             "id": ("s", args.conn_id),
             "uuid": ("s", str(args.uuid)),
             "type": ("s", "802-11-wireless"),
-            "autoconnect": ("b", args.auto),
+            "autoconnect": ("b", bool(hasattr(args, "auto") and args.auto)),
         },
         "802-11-wireless": {
             "mode": ("s", "infrastructure"),
@@ -89,13 +89,14 @@ def add_wifi_psk_connection_profile(args: Namespace) -> str:
     }
 
     # To bind the new connection to a specific interface, use this:
-    if args.interface_name:
+    if hasattr(args, "interface_name") and args.interface_name:
         properties["connection"]["interface-name"] = ("s", args.interface_name)
 
     s = NetworkManagerSettings()
-    addconnection = s.add_connection if args.save else s.add_connection_unsaved
+    save = bool(hasattr(args, "save") and args.save)
+    addconnection = s.add_connection if save else s.add_connection_unsaved
     connection_settings_dbus_path = addconnection(properties)
-    created = "created and saved" if args.save else "created"
+    created = "created and saved" if save else "created"
     info(f"New unsaved connection profile {created}, show it with:")
     info(f'nmcli connection show "{args.conn_id}"|grep -v -e -- -e default')
     info("Settings used:")

--- a/examples/block/delete-connection-by-uuid.py
+++ b/examples/block/delete-connection-by-uuid.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Update a property of a connection profile, looked up by connection id
+#
+# The IPv4 settings of connections profiles are documented here:
+# https://networkmanager.dev/docs/api/latest/settings-ipv4.html
+#
+import logging
+import sdbus
+from uuid import uuid4
+from argparse import Namespace
+from sdbus_block.networkmanager import NetworkManagerSettings
+from sdbus_block.networkmanager import NetworkConnectionSettings
+
+
+def delete_connection_by_uuid(uuid: str) -> bool:
+    """Find and delete the connection identified by the given UUID"""
+    settings_manager = NetworkManagerSettings()
+    connection_path = settings_manager.get_connection_by_uuid(uuid)
+    if not connection_path:
+        logging.getLogger().fatal(f"Connection {uuid} for deletion not found")
+        return False
+    connection_settings = NetworkConnectionSettings(connection_path)
+    connection_settings.delete()
+    return True
+
+
+def create_and_delete_wifi_psk_connection_(args: Namespace) -> bool:
+    """Add a temporary (not yet saved) network connection profile
+    :param Namespace args: autoconnect, conn_id, psk, save, ssid, uuid
+    :return: dbus connection path of the created connection profile
+    """
+    add_wifi_psk_connection = __import__("add-wifi-psk-connection")
+    if not add_wifi_psk_connection.add_wifi_psk_connection(args):
+        return False
+    return delete_connection_by_uuid(str(args.uuid))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="%(message)s", level=logging.WARNING)
+    sdbus.set_default_bus(sdbus.sd_bus_open_system())
+    args = Namespace(conn_id="Example", uuid=uuid4(), ssid="S", psk="Password")
+    if create_and_delete_wifi_psk_connection_(args):
+        print(f"Succeeded in creating and deleting connection {args.uuid}")


### PR DESCRIPTION
Demonstrate finding a connection by a known UUID by using `get_connection_by_uuid()` and demonstrate deleting it as well.

Use the `add-wifi-psk-connection` example to create a temporary WiFI connection with a given UUID.
