### PR TITLE
To avoid circular imports, move the MixIn into a base module

### DIFF
--- a/sdbus_async/networkmanager/settings.py
+++ b/sdbus_async/networkmanager/settings.py
@@ -20,72 +20,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, fields
-from functools import lru_cache
-from typing import Any, Dict, List, Optional, Type, cast
+from typing import Any, Dict, List, Optional
 
-from .types import (
-    NetworkManagerConnectionProperties,
-    NetworkManagerSettingsDomain,
-)
+from .settings.base import NetworkManagerSettingsMixin
+from .types import NetworkManagerConnectionProperties
 
 # See https://networkmanager.dev/docs/api/latest/nm-settings-dbus.html
 # for list of all settings
-
-
-class NetworkManagerSettingsMixin:
-
-    def to_dbus(self) -> NetworkManagerSettingsDomain:
-        new_dict: NetworkManagerSettingsDomain = {}
-
-        for x in fields(self):
-            value = getattr(self, x.name)
-            if value is None:
-                continue
-
-            if x.metadata['dbus_type'] == 'aa{sv}':
-                packed_variant = ('aa{sv}', [x.to_dbus() for x in value])
-            else:
-                packed_variant = (x.metadata['dbus_type'], value)
-
-            new_dict[x.metadata['dbus_name']] = packed_variant
-
-        return new_dict
-
-    @classmethod
-    def _unpack_variant(cls, key: str, signature: str, value: Any) -> Any:
-        if signature == 'aa{sv}':
-            inner_class = cls.setting_name_to_inner_class(key)
-            return [inner_class.from_dbus(x) for x in value]
-
-        return value
-
-    @classmethod
-    def from_dbus(cls,
-                  dbus_dict: NetworkManagerSettingsDomain,
-                  ) -> NetworkManagerSettingsMixin:
-
-        reverse_mapping = cls.setting_name_reverse_mapping()
-        unvarianted_options = {
-            reverse_mapping[k]: cls._unpack_variant(k, *v)
-            for k, v in dbus_dict.items()}
-
-        return cls(**unvarianted_options)
-
-    @classmethod
-    @lru_cache(maxsize=None)
-    def setting_name_reverse_mapping(cls) -> Dict[str, str]:
-        return {f.metadata['dbus_name']: f.name for f in fields(cls)}
-
-    @classmethod
-    @lru_cache(maxsize=None)
-    def setting_name_to_inner_class(cls, setting_name: str) -> Type[Any]:
-        for x in fields(cls):
-            if setting_name != x.metadata['dbus_name']:
-                continue
-
-            return cast(Type[Any], x.metadata['dbus_inner_class'])
-
-        raise ValueError('Inner class not found')
 
 
 @dataclass

--- a/sdbus_async/networkmanager/settings.py
+++ b/sdbus_async/networkmanager/settings.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field, fields
 from typing import Any, Dict, List, Optional
 
 from .settings.base import NetworkManagerSettingsMixin
+from .settings.datatypes import AddressData, RouteData
 from .types import NetworkManagerConnectionProperties
 
 # See https://networkmanager.dev/docs/api/latest/nm-settings-dbus.html
@@ -133,34 +134,6 @@ class ConnectionSettings(NetworkManagerSettingsMixin):
     )
     zone: Optional[str] = field(
         metadata={'dbus_name': 'zone', 'dbus_type': 's'},
-        default=None,
-    )
-
-
-@dataclass
-class AddressData(NetworkManagerSettingsMixin):
-    address: str = field(
-        metadata={'dbus_name': 'address', 'dbus_type': 's'},
-    )
-    prefix: int = field(
-        metadata={'dbus_name': 'prefix', 'dbus_type': 'u'},
-    )
-
-
-@dataclass
-class RouteData(NetworkManagerSettingsMixin):
-    dest: str = field(
-        metadata={'dbus_name': 'dest', 'dbus_type': 's'},
-    )
-    prefix: int = field(
-        metadata={'dbus_name': 'prefix', 'dbus_type': 'u'},
-    )
-    next_hop: Optional[str] = field(
-        metadata={'dbus_name': 'next-hop', 'dbus_type': 's'},
-        default=None,
-    )
-    metric: Optional[int] = field(
-        metadata={'dbus_name': 'metric', 'dbus_type': 'u'},
         default=None,
     )
 

--- a/sdbus_async/networkmanager/settings/base.py
+++ b/sdbus_async/networkmanager/settings/base.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+from dataclasses import fields
+from functools import lru_cache
+from typing import Any, Dict, Type, cast
+
+from ..types import (
+    NetworkManagerSettingsDomain,
+)
+
+
+class NetworkManagerSettingsMixin:
+    def to_dbus(self) -> NetworkManagerSettingsDomain:
+        """TODO: Add proper docstring"""
+        new_dict: NetworkManagerSettingsDomain = {}
+
+        for x in fields(self):
+            value = getattr(self, x.name)
+            if value is None:
+                continue
+
+            if x.metadata['dbus_type'] == 'aa{sv}':
+                packed_variant = ('aa{sv}', [x.to_dbus() for x in value])
+            else:
+                packed_variant = (x.metadata['dbus_type'], value)
+
+            new_dict[x.metadata['dbus_name']] = packed_variant
+
+        return new_dict
+
+    @classmethod
+    def _unpack_variant(cls, key: str, signature: str, value: Any) -> Any:
+        if signature == 'aa{sv}':
+            inner_class = cls.setting_name_to_inner_class(key)
+            return [inner_class.from_dbus(x) for x in value]
+
+        return value
+
+    @classmethod
+    def from_dbus(
+        cls,
+        dbus_dict: NetworkManagerSettingsDomain,
+    ) -> NetworkManagerSettingsMixin:
+        """TODO: Add proper docstring"""
+        reverse_mapping = cls.setting_name_reverse_mapping()
+        unvarianted_options = {
+            reverse_mapping[k]: cls._unpack_variant(k, *v)
+            for k, v in dbus_dict.items()
+        }
+        return cls(**unvarianted_options)
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def setting_name_reverse_mapping(cls) -> Dict[str, str]:
+        return {f.metadata['dbus_name']: f.name for f in fields(cls)}
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def setting_name_to_inner_class(cls, setting_name: str) -> Type[Any]:
+        for x in fields(cls):
+            if setting_name != x.metadata['dbus_name']:
+                continue
+            return cast(Type[Any], x.metadata['dbus_inner_class'])
+
+        raise ValueError('Inner class not found')

--- a/sdbus_async/networkmanager/settings/datatypes.py
+++ b/sdbus_async/networkmanager/settings/datatypes.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .base import NetworkManagerSettingsMixin
+
+
+@dataclass
+class AddressData(NetworkManagerSettingsMixin):
+    address: str = field(
+        metadata={'dbus_name': 'address', 'dbus_type': 's'},
+    )
+    prefix: int = field(
+        metadata={'dbus_name': 'prefix', 'dbus_type': 'u'},
+    )
+
+
+@dataclass
+class RouteData(NetworkManagerSettingsMixin):
+    dest: str = field(
+        metadata={'dbus_name': 'dest', 'dbus_type': 's'},
+    )
+    prefix: int = field(
+        metadata={'dbus_name': 'prefix', 'dbus_type': 'u'},
+    )
+    next_hop: Optional[str] = field(
+        metadata={'dbus_name': 'next-hop', 'dbus_type': 's'},
+        default=None,
+    )
+    metric: Optional[int] = field(
+        metadata={'dbus_name': 'metric', 'dbus_type': 'u'},
+        default=None,
+    )


### PR DESCRIPTION
Hi, this has just the first step for generating the settings dataclasses into separate files:

I had an circular import error while trying this (even tho I used "from ... import ..."), so to be clean of that, move the MixIn into a base module. Ok for you?