### PR TITLE
Settings helper: Integrate the generated dataclasses, step1, the "all-in-one-commit" PR

### DIFF
--- a/examples/async/add-wifi-psk-connection-async.py
+++ b/examples/async/add-wifi-psk-connection-async.py
@@ -44,60 +44,67 @@
 # -> org.freedesktop.NetworkManager.Settings (Settings Profile Manager)
 
 import asyncio
+import binascii
 import functools
 import pprint
 import sdbus
 import uuid
 from argparse import ArgumentParser, Namespace
-from sdbus_async.networkmanager import NetworkManagerSettings
-from sdbus_async.networkmanager import NetworkManagerConnectionProperties
+from passlib.utils.pbkdf2 import pbkdf2  # type: ignore
+from sdbus_async.networkmanager import (
+    NetworkManagerSettings as SettingsManager,
+    ConnectionProfile,
+    ConnectionSettings,
+    Ipv4Settings,
+    Ipv6Settings,
+    WirelessSettings,
+    WirelessSecuritySettings,
+)
 
 
 async def add_wifi_psk_connection_profile_async(args: Namespace) -> None:
     """Add a temporary (not yet saved) network connection profile"""
 
     # If we add many connections passing the same id, things get messy. Check:
-    if await NetworkManagerSettings().get_connections_by_id(args.conn_id):
+    if await SettingsManager().get_connections_by_id(args.conn_id):
         print(f'Connection "{args.conn_id}" exists, remove it first')
         print(f'Run: nmcli connection delete "{args.conn_id}"')
         return
 
-    properties: NetworkManagerConnectionProperties = {
-        "connection": {
-            "id": ("s", args.conn_id),
-            "uuid": ("s", str(uuid.uuid4())),
-            "type": ("s", "802-11-wireless"),
-            "autoconnect": ("b", args.auto),
-        },
-        "802-11-wireless": {
-            "mode": ("s", "infrastructure"),
-            "security": ("s", "802-11-wireless-security"),
-            "ssid": ("ay", args.ssid.encode("utf-8")),
-        },
-        "802-11-wireless-security": {
-            "key-mgmt": ("s", "wpa-psk"),
-            "auth-alg": ("s", "open"),
-            "psk": ("s", args.psk),
-        },
-        "ipv4": {"method": ("s", "auto")},
-        "ipv6": {"method": ("s", "auto")},
-    }
+    if args.key_mgmt == "wpa-psk" and len(args.password) < 64:
+        # Hash the password into a psk hash to not store it in clear form:
+        pw = pbkdf2(args.password.encode(), args.ssid.encode(), 4096, 32)
+        args.password = binascii.hexlify(pw).decode("utf-8")
+
+    profile = ConnectionProfile(
+        connection=ConnectionSettings(
+            uuid=str(uuid.uuid4()),
+            connection_type='802-11-wireless',
+            connection_id=args.conn_id,
+            autoconnect=args.auto,
+        ),
+        ipv4=Ipv4Settings(method="auto"),
+        ipv6=Ipv6Settings(method="auto"),
+        wifi=WirelessSettings(ssid=args.ssid.encode("utf-8")),
+        wifi_security=WirelessSecuritySettings(
+            key_mgmt=args.key_mgmt, auth_alg="open", psk=args.password
+        ),
+    )
 
     # To bind the new connection to a specific interface, use this:
     if args.interface_name:
-        properties["connection"]["interface-name"] = ("s", args.interface_name)
-
-    networkmanager_settings = NetworkManagerSettings()
+        profile.connection.interface_name = args.interface_name
+    networkmanager_settings = SettingsManager()
     if args.save:
-        await networkmanager_settings.add_connection(properties)
+        await networkmanager_settings.add_connection(profile.to_dbus())
         print("New connection profile created and saved, show it with:")
     else:
-        await networkmanager_settings.add_connection_unsaved(properties)
+        await networkmanager_settings.add_connection_unsaved(profile.to_dbus())
         print("New unsaved connection profile created, show it with:")
 
     print(f'nmcli connection show "{args.conn_id}"|grep -v -e -- -e default')
     print("Settings used:")
-    functools.partial(pprint.pprint, sort_dicts=False)(properties)
+    functools.partial(pprint.pprint, sort_dicts=False)(profile.to_dbus())
 
 
 if __name__ == "__main__":
@@ -105,7 +112,8 @@ if __name__ == "__main__":
     conn_id = "MyConnectionExample"
     p.add_argument("-c", dest="conn_id", default=conn_id, help="Connection Id")
     p.add_argument("-s", dest="ssid", default="CafeSSID", help="WiFi SSID")
-    p.add_argument("-p", dest="psk", default="Coffee!!", help="WiFi PSK")
+    p.add_argument("-k", dest="key_mgmt", default="wpa-psk", help="key-mgmt")
+    p.add_argument("-p", dest="password", default="Coffee!!", help="WiFi PSK")
     p.add_argument("-i", dest="interface_name", default="", help="WiFi device")
     p.add_argument("-a", dest="auto", action="store_true", help="autoconnect")
     p.add_argument("--save", dest="save", action="store_true", help="Save")

--- a/examples/async/list-connections-async.py
+++ b/examples/async/list-connections-async.py
@@ -19,6 +19,7 @@
 # | ipv6: method: disabled
 import asyncio
 import sdbus
+import pprint
 from sdbus_async.networkmanager import (
     NetworkManagerSettings,
     NetworkConnectionSettings,
@@ -29,33 +30,30 @@ from typing import List
 async def list_connection_profiles_async() -> None:
     networkmanager_settings = NetworkManagerSettings()
     connections_paths: List[str] = await networkmanager_settings.connections
-    for connection_path in connections_paths:
-        connection_settings = NetworkConnectionSettings(connection_path)
-        settings = await connection_settings.get_settings()
-        connection = settings["connection"]
+    for dbus_connection_path in connections_paths:
+        await print_connection_profile(dbus_connection_path)
 
-        # Skip connection profiles for bridges and wireless networks
-        if connection["type"][1] in ("bridge", "802-11-wireless"):
-            continue
 
-        print("-------------------------------------------------------------")
-        print("name:", connection["id"][1])
-        print("uuid:", connection["uuid"][1])
-        print("type:", connection["type"][1])
-        if "interface-name" in connection:
-            print("      interface-name:", connection["interface-name"][1])
-
-        if "ipv4" in settings:
-            ipv4 = settings["ipv4"]
-            print("ipv4: method:", ipv4["method"][1])
-            if "address-data" in ipv4:
-                for a in ipv4["address-data"][1]:
-                    print(f'      ipaddr: {a["address"][1]}/{a["prefix"][1]}')
-            if "route-metric" in ipv4:
-                print(f'      route-metric: {ipv4["route-metric"][1]}')
-
-        if "ipv6" in settings:
-            print("ipv6: method:", settings["ipv6"]["method"][1])
+async def print_connection_profile(connection_path: str) -> None:
+    connectionsettings_service = NetworkConnectionSettings(connection_path)
+    profile = await connectionsettings_service.connection_profile()
+    connection = profile.connection
+    print("-------------------------------------------------------------")
+    print("name:", connection.connection_id)
+    print("uuid:", connection.uuid)
+    print("type:", connection.connection_type)
+    if connection.interface_name:
+        print("      interface-name:", connection.interface_name)
+    if profile.ipv4:
+        print("ipv4: method:", profile.ipv4.method)
+        if profile.ipv4.address_data:
+            for address in profile.ipv4.address_data:
+                print(f'      ipaddr: {address.address}/{address.prefix}')
+        if profile.ipv4.route_metric:
+            print(f'      route-metric: {profile.ipv4.route_metric}')
+    if profile.ipv6:
+        print("ipv6: method:", profile.ipv6.method)
+    pprint.pprint(profile.to_dbus())
 
 
 if __name__ == "__main__":

--- a/sdbus_async/networkmanager/__init__.py
+++ b/sdbus_async/networkmanager/__init__.py
@@ -193,6 +193,59 @@ from .exceptions import (
     NmVpnPluginInvalidConnectionError,
     NmVpnPluginInteractiveNotSupportedError,
 )
+from .settings.connection import ConnectionSettings
+from .settings.profile import ConnectionProfile
+from .settings.ipv4 import Ipv4Settings
+from .settings.ipv6 import Ipv6Settings
+from .settings.adsl import AdslSettings
+from .settings.bluetooth import BluetoothSettings
+from .settings.bond import BondSettings
+from .settings.bond_port import BondPortSettings
+from .settings.bridge import BridgeSettings
+from .settings.bridge_port import BridgePortSettings
+from .settings.cdma import CdmaSettings
+from .settings.dcb import DcbSettings
+from .settings.ethernet import EthernetSettings
+from .settings.gsm import GsmSettings
+from .settings.hostname import HostnameSettings
+from .settings.ieee802_1x import Ieee8021XSettings
+from .settings.infiniband import InfinibandSettings
+from .settings.ip_tunnel import IpTunnelSettings
+from .settings.lowpan import LowpanSettings
+from .settings.macsec import MacsecSettings
+from .settings.macvlan import MacvlanSettings
+from .settings.match import MatchSettings
+from .settings.olpc_mesh import OlpcMeshSettings
+from .settings.ovs_bridge import OvsBridgeSettings
+from .settings.ovs_dpdk import OvsDpdkSettings
+from .settings.ovs_external_ids import OvsExternalIdsSettings
+from .settings.ovs_interface import OvsInterfaceSettings
+from .settings.ovs_patch import OvsPatchSettings
+from .settings.ovs_port import OvsPortSettings
+from .settings.ppp import PppSettings
+from .settings.pppoe import PppoeSettings
+from .settings.proxy import ProxySettings
+from .settings.serial import SerialSettings
+from .settings.team import TeamSettings
+from .settings.team_port import TeamPortSettings
+from .settings.tun import TunSettings
+from .settings.user import UserSettings
+from .settings.veth import VethSettings
+from .settings.vlan import VlanSettings
+from .settings.vpn import VpnSettings
+from .settings.vrf import VrfSettings
+from .settings.vxlan import VxlanSettings
+from .settings.wifi_p2p import WifiP2PSettings
+from .settings.wimax import WimaxSettings
+from .settings.wireguard import WireguardSettings
+from .settings.wireless import WirelessSettings
+from .settings.wireless_security import WirelessSecuritySettings
+from .settings.wpan import WpanSettings
+from .settings.datatypes import (
+    AddressData,
+    RouteData,
+    WireguardPeers,
+)
 from .types import (
     NetworkManagerSetting,
     NetworkManagerSettingsDomain,
@@ -302,6 +355,59 @@ __all__ = (
     'AccessPoint',
     'WiFiP2PPeer',
     'ConfigCheckpoint',
+
+    'ConnectionProfile',
+    'ConnectionSettings',
+    'AdslSettings',
+    'BluetoothSettings',
+    'BondPortSettings',
+    'BondSettings',
+    'BridgePortSettings',
+    'BridgeSettings',
+    'CdmaSettings',
+    'DcbSettings',
+    'EthernetSettings',
+    'GsmSettings',
+    'HostnameSettings',
+    'Ieee8021XSettings',
+    'InfinibandSettings',
+    'IpTunnelSettings',
+    'Ipv4Settings',
+    'Ipv6Settings',
+    'LowpanSettings',
+    'MacsecSettings',
+    'MacvlanSettings',
+    'MatchSettings',
+    'OlpcMeshSettings',
+    'OvsBridgeSettings',
+    'OvsDpdkSettings',
+    'OvsExternalIdsSettings',
+    'OvsInterfaceSettings',
+    'OvsPatchSettings',
+    'OvsPortSettings',
+    'PppSettings',
+    'PppoeSettings',
+    'ProxySettings',
+    'SerialSettings',
+    'TeamPortSettings',
+    'TeamSettings',
+    'TunSettings',
+    'UserSettings',
+    'VethSettings',
+    'VlanSettings',
+    'VpnSettings',
+    'VrfSettings',
+    'VxlanSettings',
+    'WifiP2PSettings',
+    'WimaxSettings',
+    'WireguardSettings',
+    'WirelessSecuritySettings',
+    'WirelessSettings',
+    'WpanSettings',
+
+    'AddressData',
+    'RouteData',
+    'WireguardPeers',
 
     'DEVICE_TYPE_TO_CLASS',
 

--- a/sdbus_async/networkmanager/objects.py
+++ b/sdbus_async/networkmanager/objects.py
@@ -63,6 +63,7 @@ from .interfaces_other import (NetworkManagerAccessPointInterfaceAsync,
                                NetworkManagerSettingsInterfaceAsync,
                                NetworkManagerVPNConnectionInterfaceAsync,
                                NetworkManagerWifiP2PPeerInterfaceAsync)
+from .settings.profile import ConnectionProfile
 
 NETWORK_MANAGER_SERVICE_NAME = 'org.freedesktop.NetworkManager'
 
@@ -159,7 +160,7 @@ class NetworkManagerSettings(NetworkManagerSettingsInterfaceAsync):
         which use the given connection identifier.
 
         :param str connection_id: The connection identifier of the connections,
-        e.g. "Ethernet connection 1"
+                                  e.g. "Wired connection 1"
         :return: List of connection profile paths using the given identifier.
         """
         connection_paths_with_matching_id = []
@@ -195,6 +196,9 @@ class NetworkConnectionSettings(
             NETWORK_MANAGER_SERVICE_NAME,
             settings_path,
             bus)
+
+    async def connection_profile(self) -> ConnectionProfile:
+        return ConnectionProfile.from_dbus(await self.get_settings())
 
 
 class NetworkDeviceGeneric(

--- a/sdbus_async/networkmanager/settings.py
+++ b/sdbus_async/networkmanager/settings.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 
 from .settings.base import NetworkManagerSettingsMixin
 from .settings.datatypes import AddressData, RouteData
+from .settings.wireless import WirelessSettings
 from .settings.wireless_security import WirelessSecuritySettings
 from .types import NetworkManagerConnectionProperties
 
@@ -257,103 +258,29 @@ class Ipv4Settings(NetworkManagerSettingsMixin):
 
 
 @dataclass
-class WifiSettings(NetworkManagerSettingsMixin):
-    ap_isolation: Optional[int] = field(
-        metadata={'dbus_name': 'ap-isolation', 'dbus_type': 'i'},
-        default=None,
-    )
-    assigned_mac_address: Optional[str] = field(
-        metadata={'dbus_name': 'assigned-mac-address', 'dbus_type': 's'},
-        default=None,
-    )
-    band: Optional[str] = field(
-        metadata={'dbus_name': 'band', 'dbus_type': 's'},
-        default=None,
-    )
-    bssid: Optional[bytes] = field(
-        metadata={'dbus_name': 'bssid', 'dbus_type': 'ay'},
-        default=None,
-    )
-    channel: Optional[int] = field(
-        metadata={'dbus_name': 'channel', 'dbus_type': 'u'},
-        default=None,
-    )
-    cloned_mac_address: Optional[bytes] = field(
-        metadata={'dbus_name': 'cloned-mac-address', 'dbus_type': 'ay'},
-        default=None,
-    )
-    generate_mac_address_mask: Optional[str] = field(
-        metadata={'dbus_name': 'generate-mac-address-mask',
-                  'dbus_type': 's'},
-        default=None,
-    )
-    hidden: Optional[bool] = field(
-        metadata={'dbus_name': 'hidden', 'dbus_type': 'b'},
-        default=None,
-    )
-    mac_address: Optional[bytes] = field(
-        metadata={'dbus_name': 'mac-address', 'dbus_type': 'ay'},
-        default=None,
-    )
-    mac_address_blacklist: Optional[List[str]] = field(
-        metadata={'dbus_name': 'mac-address-blacklist',
-                  'dbus_type': 'as'},
-        default=None,
-    )
-    mac_address_randomization: Optional[int] = field(
-        metadata={'dbus_name': 'mac-address-randomization',
-                  'dbus_type': 'u'},
-        default=None,
-    )
-    mode: Optional[str] = field(
-        metadata={'dbus_name': 'mode', 'dbus_type': 's'},
-        default=None,
-    )
-    mtu: Optional[int] = field(
-        metadata={'dbus_name': 'mtu', 'dbus_type': 'u'},
-        default=None,
-    )
-    powersave: Optional[int] = field(
-        metadata={'dbus_name': 'powersave', 'dbus_type': 'u'},
-        default=None,
-    )
-    rate: Optional[int] = field(
-        metadata={'dbus_name': 'rate', 'dbus_type': 'u'},
-        default=None,
-    )
-    seen_bssids: Optional[List[str]] = field(
-        metadata={'dbus_name': 'seen-bssids', 'dbus_type': 'as'},
-        default=None,
-    )
-    ssid: Optional[bytes] = field(
-        metadata={'dbus_name': 'ssid', 'dbus_type': 'ay'},
-        default=None,
-    )
-    tx_power: Optional[int] = field(
-        metadata={'dbus_name': 'tx-power', 'dbus_type': 'u'},
-        default=None,
-    )
-    wake_on_wlan: Optional[int] = field(
-        metadata={'dbus_name': 'wake-on-wlan', 'dbus_type': 'u'},
-        default=None,
-    )
-
-
-@dataclass
 class NetworkManngerSettings:
-    connection_settings: Optional[ConnectionSettings] = field(
+    """
+    NetworkManager is based on a concept of connection profiles, most often
+    referred to just as "connections". Connection profiles provide a network
+    configuration. When NetworkManager activates a connection profile on a
+    network device, the configuration will be applied and an active network
+    connection will be established. Users are free to create as many
+    connection profiles as they see fit. Thus they are flexible in having
+    various network configurations for different networking needs:
+    https://networkmanager.pages.freedesktop.org/NetworkManager/NetworkManager/nm-settings-dbus.html
+    """
+    connection_settings: ConnectionSettings = field(
         metadata={'dbus_name': 'connection',
                   'settings_class': ConnectionSettings},
-        default=None,
     )
     ipv4_settings: Optional[Ipv4Settings] = field(
         metadata={'dbus_name': 'ipv4',
                   'settings_class': Ipv4Settings},
         default=None,
     )
-    wifi_settings: Optional[WifiSettings] = field(
+    wifi: Optional[WirelessSettings] = field(
         metadata={'dbus_name': '802-11-wireless',
-                  'settings_class': WifiSettings},
+                  'settings_class': WirelessSettings},
         default=None,
     )
     wifi_security: Optional[WirelessSecuritySettings] = field(

--- a/sdbus_async/networkmanager/settings.py
+++ b/sdbus_async/networkmanager/settings.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 
 from .settings.base import NetworkManagerSettingsMixin
 from .settings.datatypes import AddressData, RouteData
+from .settings.wireless_security import WirelessSecuritySettings
 from .types import NetworkManagerConnectionProperties
 
 # See https://networkmanager.dev/docs/api/latest/nm-settings-dbus.html
@@ -339,90 +340,6 @@ class WifiSettings(NetworkManagerSettingsMixin):
 
 
 @dataclass
-class WifiSecuritySettings(NetworkManagerSettingsMixin):
-    auth_alg: Optional[str] = field(
-        metadata={'dbus_name': 'auth-alg', 'dbus_type': 's'},
-        default=None,
-    )
-    fils: Optional[int] = field(
-        metadata={'dbus_name': 'fils', 'dbus_type': 'i'},
-        default=None,
-    )
-    group: Optional[List[str]] = field(
-        metadata={'dbus_name': 'group', 'dbus_type': 'as'},
-        default=None,
-    )
-    key_mgmt: Optional[str] = field(
-        metadata={'dbus_name': 'key-mgmt', 'dbus_type': 's'},
-        default=None,
-    )
-    leap_password: Optional[int] = field(
-        metadata={'dbus_name': 'leap-password', 'dbus_type': 's'},
-        default=None,
-    )
-    leap_password_flags: Optional[int] = field(
-        metadata={'dbus_name': 'leap-password-flags', 'dbus_type': 'u'},
-        default=None,
-    )
-    leap_username: Optional[str] = field(
-        metadata={'dbus_name': 'leap-username', 'dbus_type': 's'},
-        default=None,
-    )
-    pairwise: Optional[List[str]] = field(
-        metadata={'dbus_name': 'pairwise', 'dbus_type': 'as'},
-        default=None,
-    )
-    pmf: Optional[int] = field(
-        metadata={'dbus_name': 'pmf', 'dbus_type': 'i'},
-        default=None,
-    )
-    proto: Optional[List[str]] = field(
-        metadata={'dbus_name': 'proto', 'dbus_type': 'as'},
-        default=None,
-    )
-    psk: Optional[str] = field(
-        metadata={'dbus_name': 'psk', 'dbus_type': 's'},
-        default=None,
-    )
-    psk_flags: Optional[int] = field(
-        metadata={'dbus_name': 'psk-flags', 'dbus_type': 'u'},
-        default=None,
-    )
-    wep_key_flags: Optional[int] = field(
-        metadata={'dbus_name': 'wep-key-flags', 'dbus_type': 'u'},
-        default=None,
-    )
-    wep_key_type: Optional[int] = field(
-        metadata={'dbus_name': 'wep-key-type', 'dbus_type': 'u'},
-        default=None,
-    )
-    wep_key0: Optional[str] = field(
-        metadata={'dbus_name': 'wep-key0', 'dbus_type': 's'},
-        default=None,
-    )
-    wep_key1: Optional[str] = field(
-        metadata={'dbus_name': 'wep-key1', 'dbus_type': 's'},
-        default=None,
-    )
-    wep_key2: Optional[str] = field(
-        metadata={'dbus_name': 'wep-key2', 'dbus_type': 's'},
-        default=None,
-    )
-    wep_key3: Optional[str] = field(
-        metadata={'dbus_name': 'wep-key3', 'dbus_type': 's'},
-        default=None,
-    )
-    wep_tx_keyidx: Optional[int] = field(
-        metadata={'dbus_name': 'wep-tx-keyidx', 'dbus_type': 'u'},
-        default=None,
-    )
-    wps_method: Optional[int] = field(
-        metadata={'dbus_name': 'wps-method', 'dbus_type': 'u'},
-        default=None,
-    )
-
-
-@dataclass
 class NetworkManngerSettings:
     connection_settings: Optional[ConnectionSettings] = field(
         metadata={'dbus_name': 'connection',
@@ -439,9 +356,9 @@ class NetworkManngerSettings:
                   'settings_class': WifiSettings},
         default=None,
     )
-    wifi_security: Optional[WifiSecuritySettings] = field(
+    wifi_security: Optional[WirelessSecuritySettings] = field(
         metadata={'dbus_name': '802-11-wireless-security',
-                  'settings_class': WifiSecuritySettings},
+                  'settings_class': WirelessSecuritySettings},
         default=None,
     )
 

--- a/sdbus_async/networkmanager/settings/__init__.py
+++ b/sdbus_async/networkmanager/settings/__init__.py
@@ -4,27 +4,28 @@
 from .connection import ConnectionSettings
 from .ipv4 import Ipv4Settings
 from .ipv6 import Ipv6Settings
-from .ethernet import EthernetSettings
-from .wireless import WirelessSettings
-from .wireless_security import WirelessSecuritySettings
-from .gsm import GsmSettings
-from .lowpan import LowpanSettings
-from .ieee802_1x import Ieee8021XSettings
 from .adsl import AdslSettings
 from .bluetooth import BluetoothSettings
 from .bond import BondSettings
+from .bond_port import BondPortSettings
 from .bridge import BridgeSettings
 from .bridge_port import BridgePortSettings
 from .cdma import CdmaSettings
 from .dcb import DcbSettings
+from .ethernet import EthernetSettings
+from .gsm import GsmSettings
+from .hostname import HostnameSettings
+from .ieee802_1x import Ieee8021XSettings
 from .infiniband import InfinibandSettings
 from .ip_tunnel import IpTunnelSettings
+from .lowpan import LowpanSettings
 from .macsec import MacsecSettings
 from .macvlan import MacvlanSettings
 from .match import MatchSettings
 from .olpc_mesh import OlpcMeshSettings
 from .ovs_bridge import OvsBridgeSettings
 from .ovs_dpdk import OvsDpdkSettings
+from .ovs_external_ids import OvsExternalIdsSettings
 from .ovs_interface import OvsInterfaceSettings
 from .ovs_patch import OvsPatchSettings
 from .ovs_port import OvsPortSettings
@@ -36,6 +37,7 @@ from .team import TeamSettings
 from .team_port import TeamPortSettings
 from .tun import TunSettings
 from .user import UserSettings
+from .veth import VethSettings
 from .vlan import VlanSettings
 from .vpn import VpnSettings
 from .vrf import VrfSettings
@@ -43,23 +45,56 @@ from .vxlan import VxlanSettings
 from .wifi_p2p import WifiP2PSettings
 from .wimax import WimaxSettings
 from .wireguard import WireguardSettings
+from .wireless import WirelessSettings
+from .wireless_security import WirelessSecuritySettings
 from .wpan import WpanSettings
-from .bond_port import BondPortSettings
-from .hostname import HostnameSettings
-from .ovs_external_ids import OvsExternalIdsSettings
-from .veth import VethSettings
+
 __all__ = (
-    'ConnectionSettings', 'Ipv4Settings', 'Ipv6Settings', 'EthernetSettings',
-    'WirelessSettings', 'WirelessSecuritySettings', 'GsmSettings',
-    'LowpanSettings', 'Ieee8021XSettings', 'AdslSettings', 'BluetoothSettings',
-    'BondSettings', 'BridgeSettings', 'BridgePortSettings', 'CdmaSettings',
-    'DcbSettings', 'InfinibandSettings', 'IpTunnelSettings', 'MacsecSettings',
-    'MacvlanSettings', 'MatchSettings', 'OlpcMeshSettings', 'OvsBridgeSettings',
-    'OvsDpdkSettings', 'OvsInterfaceSettings', 'OvsPatchSettings',
-    'OvsPortSettings', 'PppSettings', 'PppoeSettings', 'ProxySettings',
-    'SerialSettings', 'TeamSettings', 'TeamPortSettings', 'TunSettings',
-    'UserSettings', 'VlanSettings', 'VpnSettings', 'VrfSettings',
-    'VxlanSettings', 'WifiP2PSettings', 'WimaxSettings', 'WireguardSettings',
-    'WpanSettings', 'BondPortSettings', 'HostnameSettings',
-    'OvsExternalIdsSettings', 'VethSettings'
+    'ConnectionSettings',
+    'Ipv4Settings',
+    'Ipv6Settings',
+    'AdslSettings',
+    'BluetoothSettings',
+    'BondPortSettings',
+    'BondSettings',
+    'BridgePortSettings',
+    'BridgeSettings',
+    'CdmaSettings',
+    'DcbSettings',
+    'EthernetSettings',
+    'GsmSettings',
+    'HostnameSettings',
+    'Ieee8021XSettings',
+    'InfinibandSettings',
+    'IpTunnelSettings',
+    'LowpanSettings',
+    'MacsecSettings',
+    'MacvlanSettings',
+    'MatchSettings',
+    'OlpcMeshSettings',
+    'OvsBridgeSettings',
+    'OvsDpdkSettings',
+    'OvsExternalIdsSettings',
+    'OvsInterfaceSettings',
+    'OvsPatchSettings',
+    'OvsPortSettings',
+    'PppSettings',
+    'PppoeSettings',
+    'ProxySettings',
+    'SerialSettings',
+    'TeamPortSettings',
+    'TeamSettings',
+    'TunSettings',
+    'UserSettings',
+    'VethSettings',
+    'VlanSettings',
+    'VpnSettings',
+    'VrfSettings',
+    'VxlanSettings',
+    'WifiP2PSettings',
+    'WimaxSettings',
+    'WireguardSettings',
+    'WirelessSecuritySettings',
+    'WirelessSettings',
+    'WpanSettings',
 )

--- a/sdbus_async/networkmanager/settings/bond.py
+++ b/sdbus_async/networkmanager/settings/bond.py
@@ -11,11 +11,9 @@ from .base import NetworkManagerSettingsMixin
 class BondSettings(NetworkManagerSettingsMixin):
     """Bonding Settings"""
 
-    interface_name: Optional[str] = field(
+    interface_name: str = field(
         metadata={'dbus_name': 'interface-name', 'dbus_type': 's'},
-        default=None,
     )
-    options: Optional[Dict[str, str]] = field(
+    options: Dict[str, str] = field(
         metadata={'dbus_name': 'options', 'dbus_type': 'a{ss}'},
-        default={'Mode': 'Balance-Rr'},
     )

--- a/sdbus_async/networkmanager/settings/datatypes.py
+++ b/sdbus_async/networkmanager/settings/datatypes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import List, Optional
 
 from .base import NetworkManagerSettingsMixin
 
@@ -107,4 +107,17 @@ class Vlans(NetworkManagerSettingsMixin):
     )
     untagged: bool = field(
         metadata={'dbus_name': 'untagged', 'dbus_type': 'b'},
+    )
+
+
+@dataclass
+class WireguardPeers(NetworkManagerSettingsMixin):
+    public_key: str = field(
+        metadata={'dbus_name': 'public-key', 'dbus_type': 's'},
+    )
+    endpoint: int = field(
+        metadata={'dbus_name': 'endpoint', 'dbus_type': 's'},
+    )
+    allowed_ips: List[str] = field(
+        metadata={'dbus_name': 'allowed-ips', 'dbus_type': 'as'},
     )

--- a/sdbus_async/networkmanager/settings/profile.py
+++ b/sdbus_async/networkmanager/settings/profile.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any, Dict, Optional
+
+from .base import NetworkManagerSettingsMixin
+from .bridge import BridgeSettings
+from .ethernet import EthernetSettings
+from .connection import ConnectionSettings
+from .ipv4 import Ipv4Settings
+from .ipv6 import Ipv6Settings
+from .proxy import ProxySettings
+from .vpn import VpnSettings
+from .wireless import WirelessSettings
+from .wireless_security import WirelessSecuritySettings
+from .wireguard import WireguardSettings
+from ..types import NetworkManagerConnectionProperties
+
+
+@dataclass
+class ConnectionProfile:
+    """
+    NetworkManager is based on a concept of connection profiles, most often
+    referred to just as "connections". Connection profiles provide a network
+    configuration. When NetworkManager activates a connection profile on a
+    network device, the configuration will be applied and an active network
+    connection will be established. Users are free to create as many
+    connection profiles as they see fit. Thus they are flexible in having
+    various network configurations for different networking needs:
+    https://networkmanager.pages.freedesktop.org/NetworkManager/NetworkManager/nm-settings-dbus.html
+    """
+    connection: ConnectionSettings = field(
+        metadata={'dbus_name': 'connection',
+                  'settings_class': ConnectionSettings},
+    )
+    bridge: Optional[BridgeSettings] = field(
+        metadata={'dbus_name': 'bridge',
+                  'settings_class': BridgeSettings},
+        default=None,
+    )
+    ethernet: Optional[EthernetSettings] = field(
+        metadata={'dbus_name': '802-3-ethernet',
+                  'settings_class': EthernetSettings},
+        default=None,
+    )
+    ipv4: Optional[Ipv4Settings] = field(
+        metadata={'dbus_name': 'ipv4',
+                  'settings_class': Ipv4Settings},
+        default=None,
+    )
+    ipv6: Optional[Ipv6Settings] = field(
+        metadata={'dbus_name': 'ipv6',
+                  'settings_class': Ipv6Settings},
+        default=None,
+    )
+    proxy: Optional[ProxySettings] = field(
+        metadata={'dbus_name': 'proxy',
+                  'settings_class': ProxySettings},
+        default=None,
+    )
+    vpn: Optional[VpnSettings] = field(
+        metadata={'dbus_name': 'vpn',
+                  'settings_class': VpnSettings},
+        default=None,
+    )
+    wifi: Optional[WirelessSettings] = field(
+        metadata={'dbus_name': '802-11-wireless',
+                  'settings_class': WirelessSettings},
+        default=None,
+    )
+    wifi_security: Optional[WirelessSecuritySettings] = field(
+        metadata={'dbus_name': '802-11-wireless-security',
+                  'settings_class': WirelessSecuritySettings},
+        default=None,
+    )
+    wireguard: Optional[WireguardSettings] = field(
+        metadata={'dbus_name': 'wireguard',
+                  'settings_class': WireguardSettings},
+        default=None,
+    )
+
+    def to_dbus(self) -> NetworkManagerConnectionProperties:
+        new_dict: NetworkManagerConnectionProperties = {}
+
+        for x in fields(self):
+            value = getattr(self, x.name)
+            if value is None:
+                continue
+
+            new_dict[x.metadata['dbus_name']] = value.to_dbus()
+
+        return new_dict
+
+    @property
+    def dbus_name_to_settings_class(self) -> Dict[str, str]:
+        return {f.metadata['dbus_name']: f.name
+                for f in fields(self)}
+
+    @classmethod
+    def from_dbus(cls, dbus_dict: NetworkManagerConnectionProperties
+                  ) -> ConnectionProfile:
+        for domain in ("ipv4", "ipv6"):
+            group = dbus_dict.get(domain, None)
+            if group:
+                for key in ("addresses", "routes"):
+                    group.pop(key, None)
+        try:
+            unvarianted_options: Dict[str, Any] = {
+                SETTING_DBUS_NAME_TO_NAME[k]: SETTING_TO_CLASS[k].from_dbus(v)
+                for k, v in dbus_dict.items()}
+        except KeyError as e:
+            print(dbus_dict)
+            raise e
+        return cls(**unvarianted_options)
+
+
+SETTING_DBUS_NAME_TO_NAME: Dict[str, str] = {
+    f.metadata['dbus_name']: f.name
+    for f in fields(ConnectionProfile)
+}
+
+SETTING_TO_CLASS: Dict[str, NetworkManagerSettingsMixin] = {
+    f.metadata['dbus_name']: f.metadata['settings_class']
+    for f in fields(ConnectionProfile)
+}

--- a/sdbus_async/networkmanager/settings/wireguard.py
+++ b/sdbus_async/networkmanager/settings/wireguard.py
@@ -3,14 +3,20 @@
 # if possible, please make changes by also updating the script.
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import List, Optional
 from .base import NetworkManagerSettingsMixin
+from .datatypes import WireguardPeers
 
 
 @dataclass
 class WireguardSettings(NetworkManagerSettingsMixin):
     """WireGuard Settings"""
 
+    peers: List[WireguardPeers] = field(
+        metadata={'dbus_name': 'peers',
+                  'dbus_type': 'aa{sv}',
+                  'dbus_inner_class': WireguardPeers},
+    )
     fwmark: Optional[int] = field(
         metadata={'dbus_name': 'fwmark', 'dbus_type': 'u'},
         default=None,


### PR DESCRIPTION
[PATCH 1/x] Commit it all in one go with working examples

I wanted to split this into as-small-as-possible individual commits
and small PRs but have no time now, pushing as one to make it
accessible for review. maybe split into smaller if needed for
review, but it does not appear to large for one commit now.

Let's see.

It is working with the tow updated examples on my system, so
it has real-live validation.

The maybe not-obvious small changes and additiona are fixes
for the real-live query from examples/async/list-connections-async.py
by reading the many different VPNs and other connections on my system.