### PR TITLE
Add to_settings_dict() complementing from_settings_dict()

### DIFF
--- a/examples/async/update-connection-async.py
+++ b/examples/async/update-connection-async.py
@@ -3,12 +3,21 @@
 #
 # Update a property of a connection profile, looked up by connection id
 #
+# This version uses connection_manager.connection_profile().to_settings_dict()
+# to retrieve the connection profile from NetworkManager as a settings dict.
+#
+# It then updates it dynamically using the given arguments:
+# The default is to set ipv4.dns-search to ["domain1.com", "domain2.com"].
+#
+# The dynamically updated dict is then used to update connection profile of NM.
+#
 # The IPv4 settings of connections profiles are documented here:
 # https://networkmanager.dev/docs/api/latest/settings-ipv4.html
 #
 import asyncio
 import sdbus
 from functools import partial
+from sdbus_async.networkmanager import ConnectionProfile
 from sdbus_async.networkmanager import NetworkManagerSettings
 from sdbus_async.networkmanager import NetworkConnectionSettings
 from pprint import pprint
@@ -17,24 +26,34 @@ from typing import Any, Dict
 
 async def update_connection_async(args: Dict[str, Any]) -> None:
     """Update the settings for [key][entry] of the 1st matching connection"""
+
+    # Get the connection path of the connection(s) with the recieved id
     fn = NetworkManagerSettings().get_connections_by_id(args["connection_id"])
     connection_paths = await fn
-    settings_domain, setting = args["connection_setting"]
-    if connection_paths:
-        connection_settings = NetworkConnectionSettings(connection_paths[0])
-        properties = await connection_settings.get_settings()
-        # For compatibility with old tools, NM adds and prefers them, delete:
-        properties["ipv4"].pop("addresses")  # -> Use ["ipv4"]["address-data"]
-        properties["ipv4"].pop("routes")  # ----> Use ["ipv4"]["route-data"]
+    if not connection_paths:
+        print(f"No connection {id}, create with add-wifi-psk-connection-async")
+        return
 
-        # Update the setting's value in the given configuration group:
-        properties[settings_domain][setting] = args["value"]
-        await connection_settings.update(properties)
+    # Get the profile settings of the first connecttion with given id
+    connection_manager = NetworkConnectionSettings(connection_paths[0])
+    existing_connection_profile = await connection_manager.connection_profile()
+    settings = existing_connection_profile.to_settings_dict()
 
-        print(f'Updated {properties["connection"]["uuid"]}.{settings_domain}:')
-        partial(pprint, sort_dicts=False)(properties[settings_domain])
-    else:
-        print(f"No connection matching {id}")
+    # Update the given setting's property using the given value
+    setting, property = args["connection_setting"]
+    settings[setting][property] = args["value"]
+
+    # Get a new ConnectionProfile with the change incorporated
+    new_connection_profile = ConnectionProfile.from_settings_dict(settings)
+
+    # Update the new ConnectionProfile in NetworkManager's configuration
+    await connection_manager.update(new_connection_profile.to_dbus())
+
+    print(f'Updated {new_connection_profile.connection.uuid}.{setting}:')
+    partial(pprint, sort_dicts=False)(settings)
+
+    # Restore the previous connection profile:
+    await connection_manager.update(existing_connection_profile.to_dbus())
 
 
 if __name__ == "__main__":
@@ -43,7 +62,6 @@ if __name__ == "__main__":
         # Set MyConnectionExample.ipv4.dns-search to "domain1.com,domain2.com":
         "connection_id": "MyConnectionExample",
         "connection_setting": ("ipv4", "dns-search"),
-        # "as" is the so-called DBus signature, it means "array of strings":
-        "value": ("as", ["domain1.com", "domain2.com"]),
+        "value": ["domain1.com", "domain2.com"],
     }
     asyncio.run(update_connection_async(args))

--- a/sdbus_async/networkmanager/__init__.py
+++ b/sdbus_async/networkmanager/__init__.py
@@ -250,6 +250,7 @@ from .types import (
     NetworkManagerSetting,
     NetworkManagerSettingsDomain,
     NetworkManagerConnectionProperties,
+    SettingsDict,
 )
 
 DEVICE_TYPE_TO_CLASS = {
@@ -479,4 +480,5 @@ __all__ = (
     'NetworkManagerSetting',
     'NetworkManagerSettingsDomain',
     'NetworkManagerConnectionProperties',
+    'SettingsDict',
 )

--- a/sdbus_async/networkmanager/objects.py
+++ b/sdbus_async/networkmanager/objects.py
@@ -64,6 +64,7 @@ from .interfaces_other import (NetworkManagerAccessPointInterfaceAsync,
                                NetworkManagerVPNConnectionInterfaceAsync,
                                NetworkManagerWifiP2PPeerInterfaceAsync)
 from .settings.profile import ConnectionProfile
+from .types import NetworkManagerConnectionProperties
 
 NETWORK_MANAGER_SERVICE_NAME = 'org.freedesktop.NetworkManager'
 
@@ -172,6 +173,19 @@ class NetworkManagerSettings(NetworkManagerSettingsInterfaceAsync):
             if settings_properites["connection"]["id"][1] == connection_id:
                 connection_paths_with_matching_id.append(connection_path)
         return connection_paths_with_matching_id
+
+    async def get_settings_by_uuid(
+        self, connection_uuid: str
+    ) -> NetworkManagerConnectionProperties:
+        connection = await self.get_connection_by_uuid(connection_uuid)
+        connection_manager = NetworkConnectionSettings(connection)
+        connection_settings = await connection_manager.get_settings()
+        return connection_settings
+
+    async def delete_connection_by_uuid(self, connection_uuid: str) -> None:
+        conn_dbus_path = await self.get_connection_by_uuid(connection_uuid)
+        connection_settings_manager = NetworkConnectionSettings(conn_dbus_path)
+        await connection_settings_manager.delete()
 
 
 class NetworkConnectionSettings(

--- a/sdbus_async/networkmanager/types.py
+++ b/sdbus_async/networkmanager/types.py
@@ -27,3 +27,6 @@ NetworkManagerSettingsDomain = Dict[str, NetworkManagerSetting]
 
 # All settings and properites of a connection, e.g. returned by get_settings()
 NetworkManagerConnectionProperties = Dict[str, NetworkManagerSettingsDomain]
+
+# All settings and properites of a connection, but without dbus signatures
+SettingsDict = Dict[str, Dict[str, Any]]

--- a/tests/async/test_get_settings.py
+++ b/tests/async/test_get_settings.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: LGPL-2.1-or-later
+import asyncio
+import unittest
+import pytest
+import sdbus
+from sdbus_async.networkmanager import (
+    ConnectionProfile,
+    NetworkManagerSettings as SettingsManager,
+    NetworkManagerConnectionProperties as ConnectionProfileDict,
+)
+
+
+def profile_with_autoconnect_set_to(autoconnect: bool) -> ConnectionProfile:
+    dummy_profile: ConnectionProfileDict = {
+        "connection": {
+            "id": ("s", 'DummyConnection'),
+            "uuid": ("s", '16ea7af1-0e35-4036-831e-ced975f48510'),
+            "type": ("s", "dummy"),
+            "autoconnect": ("b", autoconnect),
+            "interface-name": ("s", "dummy-notused0"),
+        },
+    }
+    profile_from_dbus_dict = ConnectionProfile.from_dbus(dummy_profile)
+    # Assert that ConnectionProfile.from_dbus parsed autoconnect correctly:
+    assert profile_from_dbus_dict.connection.autoconnect is autoconnect
+    return profile_from_dbus_dict
+
+
+def set_sdbus_default_bus() -> None:
+    sdbus.set_default_bus(sdbus.sd_bus_open_system())
+
+
+async def get_settings_by_networkmanager(
+    profile: ConnectionProfileDict,
+) -> ConnectionProfileDict:
+    """Add a connection and return the settings of NetworkManager
+    Uses the helper method get_gettings_by_uuid() which uses get_settings()
+
+    Requires access and permissions to access a running NetworkManager.
+    The added (dummy) connection is not saved and deleted immediately"""
+    manager = SettingsManager()
+
+    # Temporarily add the new Wifi connection to NetworkManager:
+    await manager.add_connection_unsaved(profile)
+
+    # Get the settings of the temporary connection from NetworkManager:
+    uuid = profile["connection"]["uuid"][1]
+    connection_profile_dict = await manager.get_settings_by_uuid(uuid)
+
+    # Remove the temporay connection (now that we have read its settings):
+    await manager.delete_connection_by_uuid(uuid)
+    return connection_profile_dict
+
+
+@pytest.mark.asyncio
+async def test_autoconnect_false_returned_by_networkmanager() -> None:
+    """Test get_settings_by_uuid() and check that autoconnect = False is set"""
+    set_sdbus_default_bus()
+
+    # Set autoconnect = ("b", False) and expect it to be returned by NM:
+    profile_test = profile_with_autoconnect_set_to(autoconnect=False).to_dbus()
+    profile_from_manager = await get_settings_by_networkmanager(profile_test)
+    # Assert that NetworkManager did return autoconnect=False (default is True)
+    unittest.TestCase().assertTupleEqual(
+        profile_from_manager["connection"]["autoconnect"], ("b", False)
+    )
+
+
+@pytest.mark.asyncio
+async def test_autoconnect_true_not_returned_by_networkmanager() -> None:
+    """Check autoconnect=True (is default) is not returned by get_settings()"""
+    set_sdbus_default_bus()
+
+    # Set autoconnect = ("b", True) and expect to not be returned by NM:
+    # (NetworkManager does not return a property if it has the default value)
+    profile_test = profile_with_autoconnect_set_to(autoconnect=True).to_dbus()
+    unittest.TestCase().assertTupleEqual(
+        profile_test["connection"]["autoconnect"], ("b", True)
+    )
+    # Assert that NetworkManager did not return autoconnect (default is True)
+    profile_from_manager = await get_settings_by_networkmanager(profile_test)
+    assert "autoconnect" not in profile_from_manager["connection"]
+
+
+async def check_to_settings_dict_profile_eqal_to_from_settings_dict() -> None:
+    """Async main function to run all tests when not run by pytest"""
+    """The tests can be run by pytest (and from IDEs by running this module)"""
+    set_sdbus_default_bus()
+    await test_autoconnect_false_returned_by_networkmanager()
+    await test_autoconnect_true_not_returned_by_networkmanager()
+
+
+if __name__ == "__main__":
+    """Main function to run all tests when not run by pytest"""
+    asyncio.run(check_to_settings_dict_profile_eqal_to_from_settings_dict())

--- a/tests/async/test_get_settings.py
+++ b/tests/async/test_get_settings.py
@@ -83,12 +83,34 @@ async def test_autoconnect_true_not_returned_by_networkmanager() -> None:
     assert "autoconnect" not in profile_from_manager["connection"]
 
 
+def test_autoconnect_true_returned_by_settings_dict_when_requested() -> None:
+    """to_settings_dict(defaults=True) returns autoconnect=True (is default)"""
+    profile_from_dbus_dict = profile_with_autoconnect_set_to(True)
+    settings_dict = profile_from_dbus_dict.to_settings_dict(defaults=True)
+    assert settings_dict["connection"]["autoconnect"] is True
+
+
+def test_autoconnect_true_not_returned_by_to_settings_dict() -> None:
+    """to_settings_dict(defaults=False) does not return autoconnect=True"""
+
+    # Like checked by test_autoconnect_true_not_returned_by_networkmanager()
+    # above (which checks that get_settings) does not return autoconnect=True
+    # (because it is the default), test the same for .to_settings_dict():
+    profile_from_dbus_dict = profile_with_autoconnect_set_to(True)
+    settings_dict = profile_from_dbus_dict.to_settings_dict(defaults=False)
+
+    # Assert that networkmanager did not return autoconnect (default is True)
+    assert "autoconnect" not in settings_dict["connection"]
+
+
 async def check_to_settings_dict_profile_eqal_to_from_settings_dict() -> None:
     """Async main function to run all tests when not run by pytest"""
     """The tests can be run by pytest (and from IDEs by running this module)"""
     set_sdbus_default_bus()
     await test_autoconnect_false_returned_by_networkmanager()
     await test_autoconnect_true_not_returned_by_networkmanager()
+    test_autoconnect_true_returned_by_settings_dict_when_requested()
+    test_autoconnect_true_not_returned_by_to_settings_dict()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@igo95862 This adds to_settings_dict() with tests and an example updated to use it.

I've split this into 3 commits to make it easier to review.

The new functions for the library are very small, only the tests are large, the show the functionality.

And [examples/async/update-connection-async.py](https://github.com/python-sdbus/python-sdbus-networkmanager/compare/settings-helper...bernhardkaindl:settings-helper-to_settings_dict?expand=1#diff-2753b5cbe2ca46e6aa3ba667c7d1b2e935d3e092c2f8618439b62968a3a22c7d) is updated.

It shows a simple example how I'm using the settings_dict added by this (and the previous commit) to convert to and from a simple dict which is also good for conversion to and from JSON for RPC using JSON-RPC.

The 1st commit of this PR adds new helpers used by the tests added in the tests for it.