### PR TITLE
For merge of #14: revert changes to add-wifi-psk-connection

### DIFF
--- a/examples/async/add-wifi-psk-connection-async.py
+++ b/examples/async/add-wifi-psk-connection-async.py
@@ -3,7 +3,7 @@
 #
 # Example to create a new WiFi-PSK network connection profile:
 #
-# $ examples/async/add-wifi-psk-connection-async.py --help
+# $ add-wifi-psk-connection.py --help
 # usage: add-wifi-psk-connection.py [-h] [-c CONN_ID] [-s SSID] [-p PSK]
 #                                   [-i INTERFACE_NAME] [-a] [--save]
 #
@@ -12,7 +12,6 @@
 # optional arguments:
 #   -h, --help         show this help message and exit
 #   -c CONN_ID         Connection Id
-#   -u UUID            Connection UUID
 #   -s SSID            WiFi SSID
 #   -p PSK             WiFi PSK
 #   -i INTERFACE_NAME  WiFi device
@@ -46,34 +45,29 @@
 
 import asyncio
 import functools
-import logging
 import pprint
 import sdbus
-from uuid import uuid4
+import uuid
 from argparse import ArgumentParser, Namespace
 from sdbus_async.networkmanager import NetworkManagerSettings
 from sdbus_async.networkmanager import NetworkManagerConnectionProperties
 
 
-async def add_wifi_psk_connection_async(args: Namespace) -> str:
-    """Add a temporary (not yet saved) network connection profile
-    :param Namespace args: autoconnect, conn_id, psk, save, ssid, uuid
-    :return: dbus connection path of the created connection profile
-    """
-    info = logging.getLogger().info
+async def add_wifi_psk_connection_profile_async(args: Namespace) -> None:
+    """Add a temporary (not yet saved) network connection profile"""
 
     # If we add many connections passing the same id, things get messy. Check:
     if await NetworkManagerSettings().get_connections_by_id(args.conn_id):
         print(f'Connection "{args.conn_id}" exists, remove it first')
         print(f'Run: nmcli connection delete "{args.conn_id}"')
-        return ""
+        return
 
     properties: NetworkManagerConnectionProperties = {
         "connection": {
             "id": ("s", args.conn_id),
-            "uuid": ("s", str(args.uuid)),
+            "uuid": ("s", str(uuid.uuid4())),
             "type": ("s", "802-11-wireless"),
-            "autoconnect": ("b", bool(hasattr(args, "auto") and args.auto)),
+            "autoconnect": ("b", args.auto),
         },
         "802-11-wireless": {
             "mode": ("s", "infrastructure"),
@@ -90,27 +84,26 @@ async def add_wifi_psk_connection_async(args: Namespace) -> str:
     }
 
     # To bind the new connection to a specific interface, use this:
-    if hasattr(args, "interface_name") and args.interface_name:
+    if args.interface_name:
         properties["connection"]["interface-name"] = ("s", args.interface_name)
 
-    s = NetworkManagerSettings()
-    save = bool(hasattr(args, "save") and args.save)
-    addconnection = s.add_connection if save else s.add_connection_unsaved
-    connection_settings_dbus_path = await addconnection(properties)
-    created = "created and saved" if save else "created"
-    info(f"New unsaved connection profile {created}, show it with:")
-    info(f'nmcli connection show "{args.conn_id}"|grep -v -e -- -e default')
-    info("Settings used:")
-    info(functools.partial(pprint.pformat, sort_dicts=False)(properties))
-    return connection_settings_dbus_path
+    networkmanager_settings = NetworkManagerSettings()
+    if args.save:
+        await networkmanager_settings.add_connection(properties)
+        print("New connection profile created and saved, show it with:")
+    else:
+        await networkmanager_settings.add_connection_unsaved(properties)
+        print("New unsaved connection profile created, show it with:")
+
+    print(f'nmcli connection show "{args.conn_id}"|grep -v -e -- -e default')
+    print("Settings used:")
+    functools.partial(pprint.pprint, sort_dicts=False)(properties)
 
 
 if __name__ == "__main__":
-    logging.basicConfig(format="%(message)s", level=logging.INFO)
     p = ArgumentParser(description="Optional arguments have example values:")
     conn_id = "MyConnectionExample"
     p.add_argument("-c", dest="conn_id", default=conn_id, help="Connection Id")
-    p.add_argument("-u", dest="uuid", default=uuid4(), help="Connection UUID")
     p.add_argument("-s", dest="ssid", default="CafeSSID", help="WiFi SSID")
     p.add_argument("-p", dest="psk", default="Coffee!!", help="WiFi PSK")
     p.add_argument("-i", dest="interface_name", default="", help="WiFi device")
@@ -118,8 +111,4 @@ if __name__ == "__main__":
     p.add_argument("--save", dest="save", action="store_true", help="Save")
     args = p.parse_args()
     sdbus.set_default_bus(sdbus.sd_bus_open_system())
-    if connection_dpath := asyncio.run(add_wifi_psk_connection_async(args)):
-        print(f"Path of the new connection: {connection_dpath}")
-        print(f"UUID of the new connection: {args.uuid}")
-    else:
-        print("Error: No new connection created.")
+    asyncio.run(add_wifi_psk_connection_profile_async(args))

--- a/examples/block/add-wifi-psk-connection.py
+++ b/examples/block/add-wifi-psk-connection.py
@@ -3,7 +3,7 @@
 #
 # Example to create a new WiFi-PSK network connection profile:
 #
-# $ examples/block/add-wifi-psk-connection.py --help
+# $ add-wifi-psk-connection.py --help
 # usage: add-wifi-psk-connection.py [-h] [-c CONN_ID] [-s SSID] [-p PSK]
 #                                   [-i INTERFACE_NAME] [-a] [--save]
 #
@@ -12,7 +12,6 @@
 # optional arguments:
 #   -h, --help         show this help message and exit
 #   -c CONN_ID         Connection Id
-#   -u UUID            Connection UUID
 #   -s SSID            WiFi SSID
 #   -p PSK             WiFi PSK
 #   -i INTERFACE_NAME  WiFi device
@@ -45,34 +44,29 @@
 # -> org.freedesktop.NetworkManager.Settings (Settings Profile Manager)
 
 import functools
-import logging
 import pprint
 import sdbus
-from uuid import uuid4
+import uuid
 from argparse import ArgumentParser, Namespace
 from sdbus_block.networkmanager import NetworkManagerSettings
 from sdbus_block.networkmanager import NetworkManagerConnectionProperties
 
 
-def add_wifi_psk_connection(args: Namespace) -> str:
-    """Add a temporary (not yet saved) network connection profile
-    :param Namespace args: autoconnect, conn_id, psk, save, ssid, uuid
-    :return: dbus connection path of the created connection profile
-    """
-    info = logging.getLogger().info
+def add_wifi_psk_connection_profile(args: Namespace) -> None:
+    """Add a temporary (not yet saved) network connection profile"""
 
     # If we add many connections passing the same id, things get messy. Check:
     if NetworkManagerSettings().get_connections_by_id(args.conn_id):
         print(f'Connection "{args.conn_id}" exists, remove it first')
         print(f'Run: nmcli connection delete "{args.conn_id}"')
-        return ""
+        return
 
     properties: NetworkManagerConnectionProperties = {
         "connection": {
             "id": ("s", args.conn_id),
-            "uuid": ("s", str(args.uuid)),
+            "uuid": ("s", str(uuid.uuid4())),
             "type": ("s", "802-11-wireless"),
-            "autoconnect": ("b", bool(hasattr(args, "auto") and args.auto)),
+            "autoconnect": ("b", args.auto),
         },
         "802-11-wireless": {
             "mode": ("s", "infrastructure"),
@@ -89,27 +83,25 @@ def add_wifi_psk_connection(args: Namespace) -> str:
     }
 
     # To bind the new connection to a specific interface, use this:
-    if hasattr(args, "interface_name") and args.interface_name:
+    if args.interface_name:
         properties["connection"]["interface-name"] = ("s", args.interface_name)
 
-    s = NetworkManagerSettings()
-    save = bool(hasattr(args, "save") and args.save)
-    addconnection = s.add_connection if save else s.add_connection_unsaved
-    connection_settings_dbus_path = addconnection(properties)
-    created = "created and saved" if save else "created"
-    info(f"New unsaved connection profile {created}, show it with:")
-    info(f'nmcli connection show "{args.conn_id}"|grep -v -e -- -e default')
-    info("Settings used:")
-    info(functools.partial(pprint.pformat, sort_dicts=False)(properties))
-    return connection_settings_dbus_path
+    if args.save:
+        NetworkManagerSettings().add_connection(properties)
+        print("New connection profile created and saved, show it with:")
+    else:
+        NetworkManagerSettings().add_connection_unsaved(properties)
+        print("New unsaved connection profile created, show it with:")
+
+    print(f'nmcli connection show "{args.conn_id}"|grep -v -e -- -e default')
+    print("Settings used:")
+    functools.partial(pprint.pprint, sort_dicts=False)(properties)
 
 
 if __name__ == "__main__":
-    logging.basicConfig(format="%(message)s", level=logging.INFO)
     p = ArgumentParser(description="Optional arguments have example values:")
     conn_id = "MyConnectionExample"
     p.add_argument("-c", dest="conn_id", default=conn_id, help="Connection Id")
-    p.add_argument("-u", dest="uuid", default=uuid4(), help="Connection UUID")
     p.add_argument("-s", dest="ssid", default="CafeSSID", help="WiFi SSID")
     p.add_argument("-p", dest="psk", default="Coffee!!", help="WiFi PSK")
     p.add_argument("-i", dest="interface_name", default="", help="WiFi device")
@@ -117,8 +109,4 @@ if __name__ == "__main__":
     p.add_argument("--save", dest="save", action="store_true", help="Save")
     args = p.parse_args()
     sdbus.set_default_bus(sdbus.sd_bus_open_system())
-    if connection_dpath := add_wifi_psk_connection(args):
-        print(f"Path of the new connection: {connection_dpath}")
-        print(f"UUID of the new connection: {args.uuid}")
-    else:
-        print("Error: No new connection created.")
+    add_wifi_psk_connection_profile(args)


### PR DESCRIPTION
#14 has conflicting changes for the add-wifi-psk-connection examples (async and blocking).

As an alternative to #28 (which has the conflicts resolved and everything fully updated) this allows to merge #14 itself.

It reverts the changes for the add-wifi-psk-connection examples (async and blocking) in master since #14 was branched.

After #14 is merged, the version of add-wifi-psk-connection from #28 can be merged (which are further improved), or #28 does it all in one merge.