### PR TITLE
Add __about__.py providing package metadata such as __version__

### DIFF
--- a/sdbus_async/networkmanager/__about__.py
+++ b/sdbus_async/networkmanager/__about__.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Module providing package metadata such as __version__"""
+#
+# Rationale: It is common that python packages export package.__version__
+#
+# Usage:
+# - sdbus_block/networkmanager/__about_.py symlinks here.
+# - sdbus_block/networkmanager/__init__.py re-exports __version__.
+# - sdbus_async/networkmanager/__init__.py re-exports __version__.
+# - setup.py reads the varables into a dict and uses them for metadata
+#   (it should not attempt to import this file directly)
+#
+# This is tested by tests/async/test_version_async.py for async and a symlink
+# to it in tests/block (which tests sdbus_block.networkmanager.__version__)
+#
+# Other metadata like __author__, __url__ can be placed here
+# and red by setup.py by (and other packages as well, like this):
+#
+# from sdbus_async.networkmanager import __about__ as sdbus_networkmanager
+# print(sdbus_networkmanager.__version__, sdbus_networkmanager.__url__)
+#
+# This is only one of of many ways of sourcing the package version,
+# but it is standard, fast(e.g. pkg_resources is slow), works also when packaged
+# in archvies such as pyinstaller and does not require additional packages:
+# https://packaging.python.org/en/latest/guides/single-sourcing-package-version/
+#
+# In case the project would switch to pyproject.toml and poetry, e.g.
+# this plugin can be used to update the python module providing __version__:
+# https://github.com/monim67/poetry-bumpversion
+
+__version__ = '1.2.0'

--- a/sdbus_async/networkmanager/__init__.py
+++ b/sdbus_async/networkmanager/__init__.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 from __future__ import annotations
 
+from .__about__ import __version__
 from .enums import (
     AccessPointCapabilities,
     BluetoothCapabilities,
@@ -264,6 +265,8 @@ DEVICE_TYPE_TO_CLASS = {
 
 
 __all__ = (
+    # .__about__
+    '__version__',
     # .enums
     'AccessPointCapabilities',
     'BluetoothCapabilities',

--- a/sdbus_block/networkmanager/__about__.py
+++ b/sdbus_block/networkmanager/__about__.py
@@ -1,0 +1,1 @@
+../../sdbus_async/networkmanager/__about__.py

--- a/sdbus_block/networkmanager/__init__.py
+++ b/sdbus_block/networkmanager/__init__.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 from __future__ import annotations
 
+from .__about__ import __version__
 from .enums import (
     AccessPointCapabilities,
     BluetoothCapabilities,
@@ -264,6 +265,8 @@ DEVICE_TYPE_TO_CLASS = {
 
 
 __all__ = (
+    # .__about__
+    '__version__',
     # .enums
     'AccessPointCapabilities',
     'BluetoothCapabilities',

--- a/setup.py
+++ b/setup.py
@@ -20,16 +20,21 @@
 from __future__ import annotations
 
 from setuptools import setup
+from typing import Dict
 
 with open('./README.md') as f:
     long_description = f.read()
+
+metadata: Dict[str, str] = {}
+with open('sdbus_async/networkmanager/__about__.py') as fp:
+    exec(fp.read(), metadata)
 
 setup(
     name='sdbus-networkmanager',
     description=('NetworkManager binds for sdbus.'),
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='1.2.0',
+    version=metadata['__version__'],
     url='https://github.com/igo95862/python-sdbus',
     author='igo95862',
     author_email='igo95862@yandex.ru',

--- a/tests/async/test_version_async.py
+++ b/tests/async/test_version_async.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+def test_version_attribute() -> None:
+    """Test module.__version__ matching python setup.py --version"""
+    from importlib import import_module
+    from pathlib import PurePath
+    from subprocess import check_output
+    from sys import executable as python, path
+    from unittest import TestCase
+
+    module = import_module(f"sdbus_{PurePath(path[0]).name}.networkmanager")
+    setup_version = check_output([python, "setup.py", "--version"])
+
+    TestCase().assertEqual(module.__version__ + '\n', setup_version.decode())
+
+if __name__ == "__main__":
+    """Main function to run all tests when not run by pytest"""
+    test_version_attribute()

--- a/tests/block/test_version.py
+++ b/tests/block/test_version.py
@@ -1,0 +1,1 @@
+../async/test_version_async.py


### PR DESCRIPTION
It is common that python packages export `package.__version__`:

- Provide it for version identification so it can be logged by projects using this package.
- Other package metadata could be provided by it as well.
- Update `setup.py` to read the version for single-sourcing the version.
- Add test case testing `package.__version__` and `setup.py --version`

A complete description is in `sdbus_async/networkmanager/__about__.py`