### PR TITLE
Use the new enum ConnectionType and support using it without .value

### DIFF
--- a/examples/async/list-connections-async.py
+++ b/examples/async/list-connections-async.py
@@ -21,6 +21,7 @@ import asyncio
 import sdbus
 import pprint
 from sdbus_async.networkmanager import (
+    ConnectionType,
     NetworkManagerSettings,
     NetworkConnectionSettings,
 )
@@ -53,6 +54,8 @@ async def print_connection_profile(connection_path: str) -> None:
             print(f'      route-metric: {profile.ipv4.route_metric}')
     if profile.ipv6:
         print("ipv6: method:", profile.ipv6.method)
+    if connection.connection_type == ConnectionType.WIFI.value:
+        print("SSID:", profile.wireless.ssid.decode())
     pprint.pprint(profile.to_settings_dict(), sort_dicts=False)
 
 

--- a/examples/async/list-connections-async.py
+++ b/examples/async/list-connections-async.py
@@ -54,8 +54,10 @@ async def print_connection_profile(connection_path: str) -> None:
             print(f'      route-metric: {profile.ipv4.route_metric}')
     if profile.ipv6:
         print("ipv6: method:", profile.ipv6.method)
-    if connection.connection_type == ConnectionType.WIFI.value:
-        print("SSID:", profile.wireless.ssid.decode())
+    if connection.connection_type == ConnectionType.WIFI:
+        assert profile.wireless
+        assert profile.wireless.ssid
+        print("ssid:", profile.wireless.ssid.decode())
     pprint.pprint(profile.to_settings_dict(), sort_dicts=False)
 
 

--- a/sdbus_async/networkmanager/enums.py
+++ b/sdbus_async/networkmanager/enums.py
@@ -557,6 +557,10 @@ class ConnectionType(str, Enum):
     WIFI = "802-11-wireless"
     WPAN = "wpan"
 
+    # https://www.cosmicpython.com/blog/2020-10-27-i-hate-enums.html
+    def __str__(self) -> str:
+        """str method to avoid having to use .value to get the Enum value"""
+        return str.__str__(self)
 
 class DeviceType(IntEnum):
     """Device Type


### PR DESCRIPTION
@igo95862: This uses the new `enum ConnectionType` and improves it to not require to use `.value`:

The article https://www.cosmicpython.com/blog/2020-10-27-i-hate-enums.html descibe shortcomings of enums with `str`:
```py 
class ConnectionType(str, Enum):
     ADSL = "adsl"
     BLUETOOTH = "bluetooth"
     ...
```
The blog shows need to use it using `.value because the `enum` itself does not provide a proper `def __str__()`.
```py
    if connection.connection_type == ConnectionType.WIFI.value:
         print("SSID:", profile.wireless.ssid.decode())
```
This gist provided with the blog demonstrates and tests providing `def __str__()` to improve this:
https://gist.github.com/hjwp/405f04802ea558f042728ec5edbb4e62

By providing it like described in the blog article, the issue (danger forgetting to add `.value`) is solved:
```py
-    if connection.connection_type == ConnectionType.WIFI.value:
+    if connection.connection_type == ConnectionType.WIFI:
         print("SSID:", profile.wireless.ssid.decode())
```