### PR TITLE
networkmanager/objects.py: Syncronice new helpers from async to block

### DIFF
--- a/examples/async/delete-connection-by-uuid-async.py
+++ b/examples/async/delete-connection-by-uuid-async.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Update a property of a connection profile, looked up by connection id
-#
-# The IPv4 settings of connections profiles are documented here:
-# https://networkmanager.dev/docs/api/latest/settings-ipv4.html
+# Create and delete a connection profile using the unique connection uuid
 #
 import asyncio
 import logging
@@ -12,18 +9,16 @@ import sdbus
 from uuid import uuid4
 from argparse import Namespace
 from sdbus_async.networkmanager import NetworkManagerSettings
-from sdbus_async.networkmanager import NetworkConnectionSettings
+from sdbus_async.networkmanager import NmSettingsInvalidConnectionError
 
 
 async def delete_connection_by_uuid(uuid: str) -> bool:
     """Find and delete the connection identified by the given UUID"""
-    settings_manager = NetworkManagerSettings()
-    connection_path = await settings_manager.get_connection_by_uuid(uuid)
-    if not connection_path:
+    try:
+        await NetworkManagerSettings().delete_connection_by_uuid(uuid)
+    except NmSettingsInvalidConnectionError:
         logging.getLogger().fatal(f"Connection {uuid} for deletion not found")
         return False
-    connection_settings = NetworkConnectionSettings(connection_path)
-    await connection_settings.delete()
     return True
 
 

--- a/examples/block/delete-connection-by-uuid.py
+++ b/examples/block/delete-connection-by-uuid.py
@@ -1,32 +1,27 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Update a property of a connection profile, looked up by connection id
-#
-# The IPv4 settings of connections profiles are documented here:
-# https://networkmanager.dev/docs/api/latest/settings-ipv4.html
+# Create and delete a connection profile using the unique connection uuid
 #
 import logging
 import sdbus
 from uuid import uuid4
 from argparse import Namespace
 from sdbus_block.networkmanager import NetworkManagerSettings
-from sdbus_block.networkmanager import NetworkConnectionSettings
+from sdbus_block.networkmanager import NmSettingsInvalidConnectionError
 
 
 def delete_connection_by_uuid(uuid: str) -> bool:
     """Find and delete the connection identified by the given UUID"""
-    settings_manager = NetworkManagerSettings()
-    connection_path = settings_manager.get_connection_by_uuid(uuid)
-    if not connection_path:
+    try:
+        NetworkManagerSettings().delete_connection_by_uuid(uuid)
+    except NmSettingsInvalidConnectionError:
         logging.getLogger().fatal(f"Connection {uuid} for deletion not found")
         return False
-    connection_settings = NetworkConnectionSettings(connection_path)
-    connection_settings.delete()
     return True
 
 
-def create_and_delete_wifi_psk_connection_(args: Namespace) -> bool:
+def create_and_delete_wifi_psk_connection_async(args: Namespace) -> bool:
     """Add a temporary (not yet saved) network connection profile
     :param Namespace args: autoconnect, conn_id, psk, save, ssid, uuid
     :return: dbus connection path of the created connection profile
@@ -41,5 +36,5 @@ if __name__ == "__main__":
     logging.basicConfig(format="%(message)s", level=logging.WARNING)
     sdbus.set_default_bus(sdbus.sd_bus_open_system())
     args = Namespace(conn_id="Example", uuid=uuid4(), ssid="S", psk="Password")
-    if create_and_delete_wifi_psk_connection_(args):
+    if create_and_delete_wifi_psk_connection_async(args):
         print(f"Succeeded in creating and deleting connection {args.uuid}")


### PR DESCRIPTION
@igo95862: Two simple commits to bring `sdbus_block/networkmanager` in sync with `sdbus_async/networkmanager`:

-   networkmanager/objects.py: Syncronice new helpers from async to block:
    
    Add missing helper methods from sdbus_async/networkmanager:
    - get_settings_by_uuid(): - Net a nested settings dict of a connection profile
    - delete_connection_by_uuid(): Delete a profile identified by the uuid
    - connection_profile(): Get a ConnectionProfile object containing all settings

- examples: Show the use of NetworkConnectionSettings(path).connection_profile()

For `examples/block/list-connections.py` to show the SSIDs if WiFi connections, #34 should be merged as well.