### PR TITLE
Fix enum ConnectionType and use it in examples for testing

### DIFF
--- a/examples/block/netdevinfo.py
+++ b/examples/block/netdevinfo.py
@@ -9,7 +9,10 @@
 # https://networkmanager.dev/docs/api/latest/ref-dbus-devices.html
 import sdbus
 from sdbus_block.networkmanager import (
+    ConnectionType,
+    NetworkConnectionSettings,
     NetworkManager,
+    NetworkManagerSettings,
     NetworkDeviceGeneric,
     IPv4Config,
     DeviceType,
@@ -17,38 +20,89 @@ from sdbus_block.networkmanager import (
     WiFiOperationMode,
     AccessPoint,
 )
+from typing import Any, Dict, List, Optional, Tuple
+NetworkManagerAddressData = List[Dict[str, Tuple[str, Any]]]
+
+
+def get_most_recent_connection_id(ifname, dev_type) -> Optional[str]:
+    """Return the most-recently used connection_id for this device
+
+    Besides getting the currently active connection, this will succeed
+    in getting the most recent connection when a device is not connected
+    at the moment this function is executed.
+
+    It uses getattr(ConnectionType, dev_type) to get the connection_type
+    used for connection_profiles for this DeviceType.
+
+    With a slight modification, this could return the most recent connections
+    of the given device, ordered by the time of the last use of them.
+    """
+    settings_service = NetworkManagerSettings()
+    connection_paths: List[str] = settings_service.connections
+    conns = {}
+    for connection_path in connection_paths:
+        connection_manager = NetworkConnectionSettings(connection_path)
+        connection = connection_manager.connection_profile().connection
+        # Filter connection profiles matching the connection type for the device:
+        if connection.connection_type != getattr(ConnectionType, dev_type):
+            continue
+        # If the interface_name of a connection profiles is set, it must match:
+        if connection.interface_name and connection.interface_name != ifname:
+            continue
+        # If connection.timestamp is not set, it was never active. Set it to 0:
+        if not connection.timestamp:
+            connection.timestamp = 0
+        # Record the connection_ids of the matches, and timestamp is the key:
+        conns[connection.timestamp] = connection.connection_id
+    if not len(conns):
+        return None
+    # Returns the connection_id of the highest timestamp which was found:
+    return conns.get(max(conns.keys()))
 
 
 def list_networkdevice_details_blocking() -> None:
-    nm = NetworkManager()
-    devices_paths = nm.get_devices()
 
-    for device_path in devices_paths:
+    for device_path in NetworkManager().get_devices():
         generic_device = NetworkDeviceGeneric(device_path)
-        device_ip4_conf_path = generic_device.ip4_config
+        device_ip4_conf_path: str = generic_device.ip4_config
         if device_ip4_conf_path == "/":
             continue
+        if not generic_device.managed:
+            continue
+        dev_type = DeviceType(generic_device.device_type).name
+        if dev_type == DeviceType.BRIDGE.name:
+            continue
 
+        dev_name = generic_device.interface
         ip4_conf = IPv4Config(device_ip4_conf_path)
+        gateway: str = ip4_conf.gateway
 
-        print("Device: ", generic_device.interface)
-        if ip4_conf.gateway:
-            print("Gateway:", ip4_conf.gateway)
+        print("Type:   ", dev_type.title())
+        print("Name:   ", dev_name)
 
-        for ip4addr in ip4_conf.address_data:
-            print(f'Address: {ip4addr["address"][1]}/{ip4addr["prefix"][1]}')
+        if gateway:
+            print("Gateway:", gateway)
 
-        for dns in ip4_conf.nameserver_data:
+        address_data: NetworkManagerAddressData = ip4_conf.address_data
+        for inetaddr in address_data:
+            print(f'Address: {inetaddr["address"][1]}/{inetaddr["prefix"][1]}')
+
+        nameservers: NetworkManagerAddressData = ip4_conf.nameserver_data
+        for dns in nameservers:
             print("DNS:    ", dns["address"][1])
 
-        if generic_device.device_type == DeviceType.WIFI:
-            wifidevice = NetworkDeviceWireless(device_path)
-            print("Wifi:   ", WiFiOperationMode(wifidevice.mode).name.title())
-            ap = AccessPoint(wifidevice.active_access_point)
-            if ap.ssid:
-                print("SSID:   ", ap.ssid.decode("utf-8", "ignore"))
+        if dev_type == DeviceType.WIFI.name:
+            wifi = NetworkDeviceWireless(device_path)
+            print("Wifi:   ", WiFiOperationMode(wifi.mode).name.title())
+            ap = AccessPoint(wifi.active_access_point)
+            ssid: bytes = ap.ssid
+            if ssid:
+                print("SSID:   ", ssid.decode("utf-8", "ignore"))
             if ap.strength:
                 print("Signal: ", ap.strength)
+        connection_id = get_most_recent_connection_id(dev_name, dev_type)
+        if connection_id:
+            print("Profile:", connection_id)
 
         print("")
 

--- a/sdbus_async/networkmanager/enums.py
+++ b/sdbus_async/networkmanager/enums.py
@@ -489,6 +489,9 @@ class DeviceStateReason(IntEnum):
 #     sed 's/#define //;s/_SETTING_NAME//;s/ /=/' >.setting_defines
 # grep -f .connection_is_type .setting_defines |
 #     sed 's/NM_SETTING_/    /;s/6L/SIXL/;/GENERIC/d;s/=/ = /'
+# Manual edit: This resulted in WIRED instead of ETHERNET, but 
+# ETHERNET is the name used for DeviceType, so use ETHERNET instead to
+# be able to lookup connection profiles for Ethernet using DeviceType.
 #
 # One src/core/nm-device-*.c can support more than one ConnectionType,
 # thus there are more ConnectionTypes than DeviceTypes:
@@ -503,6 +506,7 @@ class ConnectionType(str, Enum):
     * BRIDGE
     * CDMA
     * DUMMY
+    * ETHERNET
     * GSM
     * INFINIBAND
     * IP_TUNNEL
@@ -522,7 +526,6 @@ class ConnectionType(str, Enum):
     * VRF
     * VXLAN
     * WIFI_P2P
-    * WIRED
     * WIREGUARD
     * WIFI
     * WPAN
@@ -533,6 +536,7 @@ class ConnectionType(str, Enum):
     BRIDGE = "bridge"
     CDMA = "cdma"
     DUMMY = "dummy"
+    ETHERNET = "802-3-ethernet"
     GSM = "gsm"
     INFINIBAND = "infiniband"
     IP_TUNNEL = "ip-tunnel"
@@ -552,7 +556,6 @@ class ConnectionType(str, Enum):
     VRF = "vrf"
     VXLAN = "vxlan"
     WIFI_P2P = "wifi-p2p"
-    WIRED = "802-3-ethernet"
     WIREGUARD = "wireguard"
     WIFI = "802-11-wireless"
     WPAN = "wpan"


### PR DESCRIPTION
Add a dictionary for getting the ConnectionType when having a DeviceType.
Used for lookup of the available connections for a given device.

Update: Replaced with a fix for a small issue in the enum ConnectionType and a real-world example of it's use.