### PR TITLE
Fix ConnectionType for "gsm" to match DeviceType.MODEM

### DIFF
--- a/sdbus_async/networkmanager/enums.py
+++ b/sdbus_async/networkmanager/enums.py
@@ -507,7 +507,7 @@ class ConnectionType(str, Enum):
     * CDMA
     * DUMMY
     * ETHERNET
-    * GSM
+    * MODEM
     * INFINIBAND
     * IP_TUNNEL
     * MACSEC
@@ -537,7 +537,7 @@ class ConnectionType(str, Enum):
     CDMA = "cdma"
     DUMMY = "dummy"
     ETHERNET = "802-3-ethernet"
-    GSM = "gsm"
+    MODEM = "gsm"
     INFINIBAND = "infiniband"
     IP_TUNNEL = "ip-tunnel"
     MACSEC = "macsec"


### PR DESCRIPTION
@igo95862: Apply the same kind of fix like in #36 for `ETHERNET` where we fixed
`ConnectionType.ETHERNET` to match `DeviceType.ETHERNET`:

Use `ConnectionType.MODEM` to match `DeviceType.MODEM` for use with getattr()
like shown in #36: `getattr(ConnectionType, "MODEM")`.

Like with the rename from .WIRED to .ETHERNET in #36, this rename
from .GSM to .MODEM is ok because the Enum ConnectionType is new,
and wasn't in a release of this library yet.