### PR TITLE
Fix exception in NetworkManagerSettings.get_connections_by_id

### DIFF
--- a/sdbus_async/networkmanager/objects.py
+++ b/sdbus_async/networkmanager/objects.py
@@ -159,6 +159,7 @@ class NetworkManagerSettings(NetworkManagerSettingsInterfaceAsync):
             NETWORK_MANAGER_SERVICE_NAME,
             '/org/freedesktop/NetworkManager/Settings',
             bus)
+        self._nm_used_bus = bus
 
     async def get_connections_by_id(self, connection_id: str) -> List[str]:
         """Helper method to get a list of connection profile paths
@@ -171,7 +172,7 @@ class NetworkManagerSettings(NetworkManagerSettingsInterfaceAsync):
         connection_paths_with_matching_id = []
         connection_paths: List[str] = await self.connections
         for connection_path in connection_paths:
-            settings = NetworkConnectionSettings(connection_path)
+            settings = NetworkConnectionSettings(connection_path, self._nm_used_bus)
             settings_properites = await settings.get_settings()
             # settings_properites["connection"]["id"][1] gives the id value:
             if settings_properites["connection"]["id"][1] == connection_id:

--- a/sdbus_block/networkmanager/objects.py
+++ b/sdbus_block/networkmanager/objects.py
@@ -154,6 +154,7 @@ class NetworkManagerSettings(NetworkManagerSettingsInterface):
             NETWORK_MANAGER_SERVICE_NAME,
             '/org/freedesktop/NetworkManager/Settings',
             bus)
+        self._nm_used_bus = bus
 
     def get_connections_by_id(self, connection_id: str) -> List[str]:
         """Helper method to get a list of connection profile paths
@@ -165,7 +166,7 @@ class NetworkManagerSettings(NetworkManagerSettingsInterface):
         """
         connection_paths_with_matching_id = []
         for connection_path in self.connections:
-            profile = NetworkConnectionSettings(connection_path)
+            profile = NetworkConnectionSettings(connection_path, self._nm_used_bus)
             # profile.get_settings()["connection"]["id"][1] gives the id value:
             if profile.get_settings()["connection"]["id"][1] == connection_id:
                 connection_paths_with_matching_id.append(connection_path)


### PR DESCRIPTION
Previously, calling `get_connections_by_id` could raise the following exception:

```
    settings_paths = await nm_settings.get_connections_by_id("eth0")
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../networkmanager/objects.py", line 177, in get_connections_by_id
    settings_properties = await settings.get_settings()
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../dbus_proxy_async_method.py", line 108, in _dbus_async_call
    reply_message = await bus.call_async(call_message)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sdbus.dbus_exceptions.DbusServiceUnknownError: The name org.freedesktop.NetworkManager was not provided by any .service files
```

This exception was discovered with the following test code:

```python
import asyncio
from sdbus import sd_bus_open_system
from sdbus_async.networkmanager import NetworkManagerSettings

async def test_get_connections_by_id():
    system_bus = sd_bus_open_system()
    nm_settings = NetworkManagerSettings(system_bus)
    settings_paths = await nm_settings.get_connections_by_id("eth0")
    print(settings_paths)

if __name__ == "__main__":
    asyncio.run(test_get_connections_by_id())
```

After this fix, the issue is resolved and get_connections_by_id works correctly without raising an exception.