### PR TITLE
add `persistent-keepalive` parameter to wireguard peers

### DIFF
--- a/sdbus_async/networkmanager/settings/datatypes.py
+++ b/sdbus_async/networkmanager/settings/datatypes.py
@@ -126,6 +126,10 @@ class WireguardPeers(NetworkManagerSettingsMixin):
         metadata={'dbus_name': 'allowed-ips', 'dbus_type': 'as'},
         default=None,
     )
+    persistent_keepalive: Optional[str] = field(
+        metadata={"dbus_name": "persistent-keepalive", "dbus_type": "u"},
+        default=None,
+    )
 
 
 @dataclass

--- a/sdbus_async/networkmanager/settings/datatypes.py
+++ b/sdbus_async/networkmanager/settings/datatypes.py
@@ -126,7 +126,7 @@ class WireguardPeers(NetworkManagerSettingsMixin):
         metadata={'dbus_name': 'allowed-ips', 'dbus_type': 'as'},
         default=None,
     )
-    persistent_keepalive: Optional[str] = field(
+    persistent_keepalive: Optional[int] = field(
         metadata={"dbus_name": "persistent-keepalive", "dbus_type": "u"},
         default=None,
     )


### PR DESCRIPTION
`NetworkManager` supports the `persistent-keepalive` parameter for wireguard peers. This MR adds this parameter for wireguard peers, so that one can read and modify the `persistent-keepalive` parameter.