### PR TITLE
fix: `WireguardPeers.endpoint` has wrong type int; should be str

### DIFF
--- a/sdbus_async/networkmanager/settings/datatypes.py
+++ b/sdbus_async/networkmanager/settings/datatypes.py
@@ -118,7 +118,7 @@ class WireguardPeers(NetworkManagerSettingsMixin):
         metadata={'dbus_name': 'public-key', 'dbus_type': 's'},
         default=None,
     )
-    endpoint: Optional[int] = field(
+    endpoint: Optional[str] = field(
         metadata={'dbus_name': 'endpoint', 'dbus_type': 's'},
         default=None,
     )


### PR DESCRIPTION
Currently `WireguardPeers.endpoint` is of type `int` but according to the dbus type it should be a string.